### PR TITLE
Update API reference

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -205,7 +205,7 @@ Path: GET /entries
 
 Get all entries from the register. For example, all updates there have ever been to the country register.
 
-*Note: Results from this API call are paginated. This call will return the first 100 entries from the first page of the register. Use `page-size` to define the number of entries you want and `page-index` to define the pages you want. The maximum `page-size` is 5000.*
+*Note: Results from this API call are paginated. This call will return the first 100 entries from the first page of the register. Use `limit` to define the maximum number of entries you want and `start` to define the entry number you want to start from (in ascending order).
 
 Example URL: https://local-authority-eng.register.gov.uk/entries?start=1&limit=10
 


### PR DESCRIPTION
Entries endpoint seems to use `start` and `limit` instead of `page-index` and `page-size`.