### PR TITLE
Changes to quick_start.md based on UR feedback

### DIFF
--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -1,7 +1,7 @@
 ## Quick start guide
 
-1. [Find the base URL for the register(s) you want to use](https://registers.cloudapps.digital/registers)
-2. [Find the endpoints you want](#apireference).
+1. [Find the base URL for the register(s) you want to use](https://registers.cloudapps.digital/registers). For example, for the 'Local authority eng' register: `https://local-authority-eng.register.gov.uk/`.
+2. [Find the endpoints you want](#apireference). For example, `/record/BIR` in `https://local-authority-eng.register.gov.uk/record/BIR/`.
 3. Add `.json`, `.yaml`, `.csv`, `.tsv`, or `.ttl` to the end of the request URL (before any query parameters) to choose the format of the response, or amend headers to `accept application/json` or equivalent.
 4. Parse register data and use it in your product or service.
 


### PR DESCRIPTION
After discussion with Registers developers, changes to the Quick Start guide were agreed:

Descriptions of 'base URL' and 'endpoint' have been altered and expanded. Base URL and endpoint examples now both use the 'Local authority eng' register instead of the 'Country' register. Links have been added/changed as appropriate.