### PR TITLE
Changes to api_reference.md subheadings (and ToC)

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -1,8 +1,6 @@
 ## <a name="apireference"></a>API reference
 
-### Find out more about a register
-
-Path: GET /register
+### GET /register
 
 View information about a register, including:  
 
@@ -43,9 +41,7 @@ Example response:
 }
 ```
 
-### Get all records
-
-Path: GET /records
+### GET /records
 
 Get all records from the register. For example, all of the countries from the country register.
 
@@ -106,9 +102,7 @@ Example response:
 }
 ```
 
-### View a specific record
-
-Path: GET /record/{field-value}
+### GET /record/{field-value}
 
 Find a specific record within a register. For example, the record for Vatican City in the country register.
 
@@ -139,9 +133,7 @@ Example response:
 }
 ```
 
-### View records that share attributes  
-
-Path: GET /records/{field-name}/{field-value}
+### GET /records/{field-name}/{field-value}  
 
 Find all records that share a field-value for a particular field. For example, all schools marked as Quaker schools from the school register.
 
@@ -199,9 +191,7 @@ Example response:
    },
 ```
 
-### View all entries
-
-Path: GET /entries
+### GET /entries
 
 Get all entries from the register. For example, all updates there have ever been to the country register.
 
@@ -308,9 +298,7 @@ Example response:
 ]
 ```
 
-### View a specific entry
-
-Path: GET /entry/{entry-number}
+### GET /entry/{entry-number}
 
 Find a specific entry from a register. For example, an update to the record for the USSR in the country register. An entry can include multiple items, which will return in a list of `item-hash`
 
@@ -334,9 +322,7 @@ Example response:
 ]
 ```
 
-### <a name="items"></a>View a specific item
-
-Path: GET /item/{item-hash}
+### <a name="items"></a>GET /item/{item-hash}
 
 Find a specific item within a register.
 
@@ -355,9 +341,7 @@ Example response:
 }
 ```
 
-### <a name="downloadreg"></a>Download the full register
-
-Path: GET /download-register
+### <a name="downloadreg"></a>GET /download-register
 
 Download the full contents of the register in a ZIP file.
 

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -358,21 +358,17 @@ You can download the new entries in 2 ways:
 * download another copy of the full register
 * download individual updated entries for the records you are using
 
-### Check for updates
-
-Path: GET /register
+### GET /register
 
 You can find the latest entry number by looking at the register information and comparing the most recent entry number with your own copy.
 
 Example request: https://country.register.gov.uk/register
 
-### Download a full new copy of the register
+### <a name="downloadreg"></a>GET /download-register
 
 See [endpoint for downloading register](#downloadreg).
 
-### Download all updates for one record
-
-Path: GET /record/{field-value}/entries
+### GET /record/{field-value}/entries
 
 Get all entries for a single record.
 

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -1,6 +1,6 @@
 ## <a name="apireference"></a>API reference
 
-### GET /register
+### `GET /register`
 
 View information about a register, including:  
 
@@ -41,7 +41,7 @@ Example response:
 }
 ```
 
-### GET /records
+### `GET /records`
 
 Get all records from the register. For example, all of the countries from the country register.
 
@@ -102,7 +102,7 @@ Example response:
 }
 ```
 
-### GET /record/{field-value}
+### `GET /record/{field-value}`
 
 Find a specific record within a register. For example, the record for Vatican City in the country register.
 
@@ -133,7 +133,7 @@ Example response:
 }
 ```
 
-### GET /records/{field-name}/{field-value}  
+### `GET /records/{field-name}/{field-value}`
 
 Find all records that share a field-value for a particular field. For example, all schools marked as Quaker schools from the school register.
 
@@ -191,7 +191,7 @@ Example response:
    },
 ```
 
-### GET /entries
+### `GET /entries`
 
 Get all entries from the register. For example, all updates there have ever been to the country register.
 
@@ -298,7 +298,7 @@ Example response:
 ]
 ```
 
-### GET /entry/{entry-number}
+### `GET /entry/{entry-number}`
 
 Find a specific entry from a register. For example, an update to the record for the USSR in the country register. An entry can include multiple items, which will return in a list of `item-hash`
 
@@ -322,7 +322,7 @@ Example response:
 ]
 ```
 
-### <a name="items"></a>GET /item/{item-hash}
+### <a name="items"></a>`GET /item/{item-hash}`
 
 Find a specific item within a register.
 
@@ -341,7 +341,7 @@ Example response:
 }
 ```
 
-### <a name="downloadreg"></a>GET /download-register
+### <a name="downloadreg"></a>`GET /download-register`
 
 Download the full contents of the register in a ZIP file.
 
@@ -358,17 +358,17 @@ You can download the new entries in 2 ways:
 * download another copy of the full register
 * download individual updated entries for the records you are using
 
-### GET /register
+### `GET /register`
 
 You can find the latest entry number by looking at the register information and comparing the most recent entry number with your own copy.
 
 Example request: https://country.register.gov.uk/register
 
-### <a name="downloadreg"></a>GET /download-register
+### <a name="downloadreg"></a>`GET /download-register`
 
 See [endpoint for downloading register](#downloadreg).
 
-### GET /record/{field-value}/entries
+### `GET /record/{field-value}/entries`
 
 Get all entries for a single record.
 


### PR DESCRIPTION
User research feedback suggested that when looking at the ToC, users felt the headings such as 'View a specific record' and 'View all entires' weren't technical enough and didn't make enough sense by themselves in the context of REST APIs. They felt that the information only made sense when they looked at the contents of each section. 

The changes in this commit change the subheadings (and therefore the ToC) to more technical names, to aid searching. This will be fed into the next round of UR in week 9 of Q3 to ascertain whether in this new form, this is easier for users to follow.