### PR TITLE
Move `GET /record/{field-value}/entries`

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -130,6 +130,41 @@ Example response:
 }
 ```
 
+### <a name="record-entries">`GET /record/{field-value}/entries`
+
+Get all entries for a single record.
+
+Example URL: `https://local-authority-eng.register.gov.uk/record/KIN/entries`
+
+Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/record/KIN/entries/ --header 'accept: application/json'`
+
+Example response:
+
+```
+[
+  {
+    "index-entry-number": "265",
+    "entry-number": "265",
+    "entry-timestamp": "2016-10-21T16:11:20Z",
+    "key": "KIN",
+    "item-hash": [
+      "sha-256:5a8571fc6e78f8688c66b72ea45f921a7cd1562b9a9b5b9dab8f49f842d1e391"
+    ]
+  },
+  {
+    "index-entry-number": "357",
+    "entry-number": "357",
+    "entry-timestamp": "2017-01-26T12:34:10Z",
+    "key": "KIN",
+    "item-hash": [
+      "sha-256:3f4da33a33c24de11cca3539f14ee663359608be0ba218d4fc05792c1d19c00f"
+    ]
+  }
+]
+```
+
+You can then download the latest item, for example entry 204 in the above example. Follow the [guidance for downloading items](#items).
+
 ### `GET /records/{field-name}/{field-value}`
 
 Find all records that share a field-value for a particular field. For example, all local authorities marked as county councils from the `local-authority-eng` register. 
@@ -364,38 +399,3 @@ Example request: `https://local-authority-eng.register.gov.uk/register`
 ### <a name="downloadreg"></a>`GET /download-register`
 
 See [endpoint for downloading register](#downloadreg).
-
-### `GET /record/{field-value}/entries`
-
-Get all entries for a single record.
-
-Example URL: `https://local-authority-eng.register.gov.uk/record/KIN/entries`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/record/KIN/entries/ --header 'accept: application/json'`
-
-Example response:
-
-```
-[
-  {
-    "index-entry-number": "265",
-    "entry-number": "265",
-    "entry-timestamp": "2016-10-21T16:11:20Z",
-    "key": "KIN",
-    "item-hash": [
-      "sha-256:5a8571fc6e78f8688c66b72ea45f921a7cd1562b9a9b5b9dab8f49f842d1e391"
-    ]
-  },
-  {
-    "index-entry-number": "357",
-    "entry-number": "357",
-    "entry-timestamp": "2017-01-26T12:34:10Z",
-    "key": "KIN",
-    "item-hash": [
-      "sha-256:3f4da33a33c24de11cca3539f14ee663359608be0ba218d4fc05792c1d19c00f"
-    ]
-  }
-]
-```
-
-You can then download the latest item, for example entry 204 in the above example. Follow the [guidance for downloading items](#items).


### PR DESCRIPTION
Move `GET /record/{field-value}/entries` from `Getting updates` section to `API Reference`

This needs review by *either* @arnau *or* @michaelabenyohai 

Thanks 