### PR TITLE
Missing asterisk in api_reference.md

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -227,7 +227,7 @@ Example response:
 
 Get all entries from the register. For example, all updates there have ever been to the `local-authority-eng` register.
 
-*Note: Results from this API call are paginated. This call will return the first 100 entries from the first page of the register. Use `limit` to define the maximum number of entries you want and `start` to define the entry number you want to start from (in ascending order).
+*Note: Results from this API call are paginated. This call will return the first 100 entries from the first page of the register. Use `limit` to define the maximum number of entries you want and `start` to define the entry number you want to start from (in ascending order).*
 
 Example URL: `https://local-authority-eng.register.gov.uk/entries?start=1&limit=10`
 


### PR DESCRIPTION
Corrected missing asterisk under `GET /entries`

Trying out the "request review from anyone in Registers"