### PR TITLE
Reorg of (support) info in troubleshooting.md

### DIFF
--- a/source/documentation/support/troubleshooting.md
+++ b/source/documentation/support/troubleshooting.md
@@ -1,3 +1,5 @@
+## Support 
+
 ### Error codes
 
 | Error code | Description           |
@@ -8,30 +10,27 @@
 
 ### Common issues
 
-Please find information below about common problems when using registers. If your issue is not included or you are struggling to use registers in your product or service, please contact the [GDS registers team](https://registers.cloudapps.digital/support.html).
-
 **Registers still in beta**
 
-Despite the beta label, registers in beta are reliable to use in products and services.
+Despite the beta label, registers in beta are reliable and ready for use in products and services.
 
 **If you can't find a specific record**
 
-If you can't find a specific record, check you have the correct field value. You must use the exact field value to get a match from the register. For example, in the country register the field value must be in capital letters.
+If you can't find a specific record, check you have the correct field value. You must use the exact field value to get a match from the register. For example, in the `local-authority-eng` register, you must capitalise the field value: 
 
-Incorrect request: https://country.register.gov.uk/record/gb
+Incorrect request: https://local-authority-eng.register.gov.uk/record/bir
 
-Correct request: https://country.register.gov.uk/record/GB
-
-**End-date field**
-
-The `end-date` field is used to note when an entry ceases to be valid. For example, in the country register, the end-date field contains the date when a country was dissolved or changed its name. For example, the `end-date` field value for East Germany is `1990-10-02`.
-
-You may need to remove records with an end-date if your product or service only requires data on existing countries.
-
-**Missing countries in country register**
-
-The country register only contains countries recognised by the Foreign and Commonwealth Office. As such, the country register does not contain territories such as Gibraltar and the Occupied Palestinian Territories. These are included in the territories register.
+Correct request: https://local-authority-eng.register.gov.uk/record/BIR
 
 **Adding additional data**
 
-If you want to combine register data with data from other sources, it can be useful to keep the data from each source in separate files and combine them at a later stage. For example, you could keep separate files for data about countries and data about territories.
+If you want to combine register data with data from other sources, you may find it useful to keep the data from each source in separate files and combine them at a later stage. For example, you could keep separate files for data about countries and for data about territories.
+
+### Technical specification
+
+GDS maintains a technical specification for registers (click [here](https://openregister.github.io/specification/)).
+
+## Contact us 
+
+If you experience difficulties using registers in your product or service, please contact the GDS registers team [here](https://registers.cloudapps.digital/support.html).
+

--- a/source/documentation/support/troubleshooting.md
+++ b/source/documentation/support/troubleshooting.md
@@ -28,9 +28,9 @@ If you want to combine register data with data from other sources, you may find 
 
 ### Technical specification
 
-GDS maintains a technical specification for registers (click [here](https://openregister.github.io/specification/)).
+GDS maintains a [technical specification for registers](https://openregister.github.io/specification/).
 
 ## Contact us 
 
-If you experience difficulties using registers in your product or service, please contact the GDS registers team [here](https://registers.cloudapps.digital/support.html).
+If you experience difficulties using registers in your product or service, please [contact the GDS registers team](https://registers.cloudapps.digital/support.html).
 


### PR DESCRIPTION
As discussed, this is a reorganisation of information pertaining to support in the API documentation. It removes information which is duplicated from the cloudapps website, and makes the support guidance more relevant to APIs 

This has been researched and we can be confident we have enough evidence (i.e. we "know" enough) to make this change now

Needs review by *either* @michaelabenyohai *or* @arnau 