### PR TITLE
Remove support_community.md reference

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,6 +7,5 @@ title: GDS Registers
 <%= partial 'documentation/using_the_api/api_reference' %>
 <%= partial 'documentation/using_the_api/rate_limits' %>
 <%= partial 'documentation/demos_casestudies/case_study' %>
-<%= partial 'documentation/support/support_community' %>
 <%= partial 'documentation/support/troubleshooting' %>
 <%= partial 'documentation/glossary' %>


### PR DESCRIPTION
This is contingent on https://github.com/alphagov/registers-tech-docs/pull/17

Assuming we adopt the changes in that PR, we can remove `support_community.md` and use the content of `troubleshooting.md` (but presumably rename it, in future). 

Needs review by *either* @michaelabenyohai *or* @arnau 