### PR TITLE
Add guidance on HTTPS

### DIFF
--- a/source/documentation/support/troubleshooting.md
+++ b/source/documentation/support/troubleshooting.md
@@ -35,3 +35,7 @@ The country register only contains countries recognised by the Foreign and Commo
 **Adding additional data**
 
 If you want to combine register data with data from other sources, it can be useful to keep the data from each source in separate files and combine them at a later stage. For example, you could keep separate files for data about countries and data about territories.
+
+### HTTPS
+
+GOV.UK Registers follows [government HTTPS security guidelines](https://www.gov.uk/service-manual/technology/using-https). This means you must make sure your service (including APIs) is only accessible through secure connections. For web-based services this means HTTPS only, with an HTTP Strict Transport Security (HSTS). 


### PR DESCRIPTION
We know users have had trouble in the past using SSL3 to consume registers. Registers don't support it because it's deprecated. Pay document this; I have copied this from there and edited it for Registers.

The placement of this is likely to change based on https://github.com/alphagov/registers-tech-docs/pull/17 but this is the content I propose to put in. 

Needs review by @michaelabenyohai 