### PR TITLE
Change "Rate limits" to "No rate limits"

### DIFF
--- a/source/documentation/using_the_api/rate_limits.md
+++ b/source/documentation/using_the_api/rate_limits.md
@@ -1,3 +1,3 @@
-## No rate limits
+## Rate limits
 
 There are no rate limits when using the registers APIs. 

--- a/source/documentation/using_the_api/rate_limits.md
+++ b/source/documentation/using_the_api/rate_limits.md
@@ -1,5 +1,3 @@
-## Rate limits
+## No rate limits
 
 There are no rate limits when using the registers APIs. 
-
-Contact the GDS registers team at <a href="mailto:registers@digital.cabinet-office.gov.uk">registers@digital.cabinet-office.gov.uk</a> if you have any questions.


### PR DESCRIPTION
It's a bit unorthodox to do this, but since it is so clear that we have no rate limits enforced, I don't see why we shouldn't just make this very simple and straightforward change. This isn't necessarily based on research but it's very minor in real terms, and is highly unlikely to impact the user journey negatively. 

This PR also removes the "contact us" element of `rate_limits.md`, which should not be necessary since there is a separate section for that.