### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.5.0
+
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
+    nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/Gemfile
+COPY Gemfile.lock /usr/src/app/Gemfile.lock
+COPY .ruby-version /usr/src/app/.ruby-version
+
+RUN bundle install
+COPY config.rb /usr/src/app/config.rb
+COPY config /usr/src/app/config
+COPY source /usr/src/app/source
+
+EXPOSE 4567
+EXPOSE 35729
+CMD ["bundle", "exec", "middleman", "server", "--bind-address", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', '~> 1.3'
 
 gem 'therubyracer'

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ If all goes well something like the following output will be displayed:
 
 You should now be able to view a live preview at http://localhost:4567.
 
+### Docker way
+
+Instead of all the above, assuming you have Docker and Docker Compose running
+in your machine, you can do:
+
+```
+docker-compose up
+```
+
 ## Build
 
 If you want to publish the website without using a build script you may need to

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,3 @@
 require 'govuk_tech_docs'
 
-GovukTechDocs.configure(self)
+GovukTechDocs.configure(self, livereload: { js_host: "localhost" })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "4567:4567"
+      - "35729:35729"
+    volumes:
+      - ./source:/usr/src/app/source


### PR DESCRIPTION
Defines a self contained Docker image and a complementary Docker Compose
configuration to simplify commands.

Caveat: Livereload doesn't work because it requires configuring the ws
host when the plugin gets activated. It's not possible with the current
setup.