### PR TITLE
add 'therubyracer' gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 gem 'govuk_tech_docs'
+
+gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     kramdown (1.16.2)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -134,6 +135,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.3.4)
+    ref (2.0.0)
     rouge (2.2.1)
     sass (3.4.25)
     servolux (0.13.0)
@@ -141,6 +143,9 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -154,6 +159,7 @@ PLATFORMS
 
 DEPENDENCIES
   govuk_tech_docs
+  therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
 


### PR DESCRIPTION
When cloning the `registers-tech-docs` repo I started getting errors if I tried to run `bundle exec middleman build` more than once (see snippet below which is output of `bundle middleman exec build --verbose`). I don't get this when building the Pay documentation, which is also built using the tech docs tool. 

It seems like it might only affect builds of the docs after this commit: https://github.com/alphagov/registers-tech-docs/commit/8d6038c788cd833ff94bc888ea2e5afaa586f015

The problem is fixable by adding `gem 'therubyracer'` to the Gemfile, which is the purpose of this PR; however, doing this isn't necessary to get the Pay documentation to build. 

```
 error  build/javascripts/application.js

(execjs):1
/usr/local/lib/ruby/gems/2.4.0/gems/execjs-2.7.0/lib/execjs/external_runtime.rb:219:in `exec_runtime'
/usr/local/lib/ruby/gems/2.4.0/gems/execjs-2.7.0/lib/execjs/external_runtime.rb:39:in `exec'
/usr/local/lib/ruby/gems/2.4.0/gems/execjs-2.7.0/lib/execjs/external_runtime.rb:21:in `eval'
/usr/local/lib/ruby/gems/2.4.0/gems/execjs-2.7.0/lib/execjs/external_runtime.rb:46:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/uglifier-3.2.0/lib/uglifier.rb:195:in `run_uglifyjs'
/usr/local/lib/ruby/gems/2.4.0/gems/uglifier-3.2.0/lib/uglifier.rb:157:in `compile'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/extensions/minify_javascript.rb:104:in `minify'
/usr/local/lib/ruby/gems/2.4.0/gems/memoist-0.16.0/lib/memoist.rb:214:in `minify'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/extensions/minify_javascript.rb:63:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/extensions/minify_css.rb:63:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-autoprefixer-2.7.1/lib/middleman-autoprefixer/extension.rb:48:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/head.rb:12:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/lint.rb:49:in `_call'
/usr/local/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/lint.rb:37:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/builder.rb:153:in `call'
/usr/local/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/mock.rb:74:in `request'
/usr/local/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/mock.rb:56:in `get'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:232:in `block in output_resource'
/usr/local/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:225:in `output_resource'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:484:in `call_with_index'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:455:in `process_incoming_jobs'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:437:in `block in worker'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:428:in `fork'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:428:in `worker'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:419:in `block in create_workers'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:418:in `each'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:418:in `each_with_index'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:418:in `create_workers'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:358:in `work_in_processes'
/usr/local/lib/ruby/gems/2.4.0/gems/parallel-1.12.1/lib/parallel.rb:264:in `map'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:137:in `output_resources'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:131:in `output_files'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:71:in `block in run!'
/usr/local/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/builder.rb:70:in `run!'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_reference.rb:43:in `send_to'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/call_with.rb:76:in `call_with'
/usr/local/lib/ruby/gems/2.4.0/gems/contracts-0.13.0/lib/contracts/method_handler.rb:138:in `block in redefine_method'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-cli-4.2.1/lib/middleman-cli/build.rb:80:in `block in build'
/usr/local/lib/ruby/gems/2.4.0/gems/activesupport-5.0.7/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-core-4.2.1/lib/middleman-core/util.rb:21:in `instrument'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-cli-4.2.1/lib/middleman-cli/build.rb:79:in `build'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `block in invoke_all'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `each'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `map'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `invoke_all'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/group.rb:232:in `dispatch'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:115:in `invoke'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor.rb:40:in `block in register'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
/usr/local/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
/usr/local/lib/ruby/gems/2.4.0/gems/middleman-cli-4.2.1/bin/middleman:70:in `<top (required)>'
/usr/local/bin/middleman:23:in `load'
/usr/local/bin/middleman:23:in `<top (required)>'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
There were errors during this build
```