### PR TITLE
Change desc of headers

### DIFF
--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -46,10 +46,10 @@ For example:
 curl https://country.register.gov.uk/record/GB.json
 ```
 
-You can also specify a format by making a request with the `accept` header. For example:
+You can also specify a format by making a request with the `Accept` header. For example:
 
 ```
-curl https://country.register.gov.uk/record/GB --header 'accept: application/json'
+curl https://country.register.gov.uk/record/GB --header 'Accept: application/json'
 ```
 
 ### Get register data and use it in your product or service.

--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -45,6 +45,7 @@ For example:
 ```
 curl https://country.register.gov.uk/record/GB.json
 ```
+
 You can also specify a format by making a request with the `accept` header. For example:
 
 ```

--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -45,8 +45,7 @@ For example:
 ```
 curl https://country.register.gov.uk/record/GB.json
 ```
-
-You can also specify a format by making a request with different headers. For example:
+You can also specify a format by making a request with the `accept` header. For example:
 
 ```
 curl https://country.register.gov.uk/record/GB --header 'accept: application/json'


### PR DESCRIPTION
Specify use of the `accept` header as opposed to more vague language:

"You can also specify a format by making a request with the `accept` header."