### PR TITLE
Use new service domain

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,14 +4,14 @@ host: registers-docs.cloudapps.digital
 # Header-related options
 show_govuk_logo: false
 service_name: Registers
-service_link: https://registers.cloudapps.digital/
+service_link: https://www.registers.service.gov.uk/
 phase: Alpha
 
 # Links to show on right-hand-side of header
 header_links:
-  Using registers: https://registers.cloudapps.digital/using-registers.html
-  Register pipeline: https://registers.cloudapps.digital/registers
-  Support: https://registers.cloudapps.digital/support.html
+  Using registers: https://www.registers.service.gov.uk/using-registers
+  Register pipeline: https://www.registers.service.gov.uk/registers
+  Support: https://www.registers.service.gov.uk/support
   Documentation: /
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,6 @@ applications:
   memory: 64M
   path: ./build
   buildpack: staticfile_buildpack
+  routes:
+    - docs.registers.service.gov.uk
+    - registers-docs.cloudapps.digital

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,8 +60,8 @@ http {
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
         add_header Strict-Transport-Security "max-age=31536000";
       <% end %>
-      if ($host != "registers-docs.cloudapps.digital") {
-        return 301 https://registers-docs.cloudapps.digital$request_uri;
+      if ($host != "docs.registers.service.gov.uk") {
+        return 301 https://docs.registers.service.gov.uk/$request_uri;
       }
     }
 

--- a/source/documentation/support/support.md
+++ b/source/documentation/support/support.md
@@ -1,4 +1,4 @@
-## Support 
+## Support
 
 ### Error codes
 
@@ -10,7 +10,7 @@
 
 ### Finding a specific record
 
-If you cannot find a specific record, check you have the correct field value. You must use the exact field value to get a match from the register. For example, in the `local-authority-eng` register, you must capitalise the field value (`BIR`): 
+If you cannot find a specific record, check you have the correct field value. You must use the exact field value to get a match from the register. For example, in the `local-authority-eng` register, you must capitalise the field value (`BIR`):
 
 Correct request: https://local-authority-eng.register.gov.uk/record/BIR
 
@@ -22,7 +22,7 @@ GOV.UK Registers follows government [HTTPS security guidelines](https://www.gov.
 
 GDS maintains a [technical specification for registers](https://openregister.github.io/specification/).
 
-## Contact us 
+## Contact us
 
-Please [contact the GDS Registers team](https://registers.cloudapps.digital/support.html) if you have difficulty using registers in your product or service.
+Please [contact the GDS Registers team](https://www.registers.service.gov.uk/support) if you have difficulty using registers in your product or service.
 


### PR DESCRIPTION
We now have `www.registers.service.gov.uk` && `docs.registers.service.gov.uk` so we want to use them throughout.