### PR TITLE
Remove registers-docs.cloudapps.digital route

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,3 @@ applications:
   buildpack: staticfile_buildpack
   routes:
     - route: docs.registers.service.gov.uk
-    - route: registers-docs.cloudapps.digital


### PR DESCRIPTION
This route is now mapped to the docs-registers-service-redirect application which redirects to docs.registers.service.gov.uk.