### PR TITLE
Show crown and update nav items

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,15 +2,14 @@
 host: registers-docs.cloudapps.digital
 
 # Header-related options
-show_govuk_logo: false
+show_govuk_logo: true
 service_name: Registers
 service_link: https://www.registers.service.gov.uk/
 phase: Alpha
 
 # Links to show on right-hand-side of header
 header_links:
-  Using registers: https://www.registers.service.gov.uk/using-registers
-  Register pipeline: https://www.registers.service.gov.uk/registers
+  Get data: https://www.registers.service.gov.uk/registers
   Support: https://www.registers.service.gov.uk/support
   Documentation: /
 


### PR DESCRIPTION
- Show the crown next to GOV.UK
- Remove the "using registers" link from the navigation