### PR TITLE
Fix seo title

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: registers-docs.cloudapps.digital
+host: docs.registers.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: GDS Registers
+title: GOV.UK Registers
 ---
 
 <%= partial 'documentation/index' %>


### PR DESCRIPTION
GOV.UK Registers instead of GDS Registers