### PR TITLE
Change instances of 'field-value' to 'key' where appropriate

### DIFF
--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -20,12 +20,12 @@ Using different endpoints, you can:
 
 * [view information about a register](#get-register) 
 * [get all records from a register](#get-records) 
-* [find a specific record within a register](#get-record-field-value) 
-* [get all entries for a single record](#get-record-field-value-entries) 
-* [find all records that share a `field-value` for a particular field](#get-records-field-name-field-value) 
+* [get a specific record within a register based on a particular key](#get-record-key) 
+* [get all entries for a single record based on a particular key](#get-record-key-entries) 
+* [get all records that share a `field-value` for a particular field](#get-records-field-name-field-value) 
 * [get all entries from a register](#get-entries)
-* [find a specific entry from a register](#get-entry-entry-number)
-* [find a specific item within a register](#get-item-item-hash)
+* [get a specific entry from a register](#get-entry-entry-number)
+* [get a specific item within a register](#get-item-item-hash)
 * [download the full contents of a register in a ZIP file](#get-download-register) 
 
 ### Choose the format of the response.

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -101,9 +101,9 @@ Example response:
 }
 ```
 
-### `GET /records/{field-value}`
+### `GET /records/{key}`
 
-Find a specific record within a register. For example, the record for the Borough Council of King's Lynn and West Norfolk in the `local-authority-eng` register. 
+Get a specific record within a register based on a particular key. For example, the record for the Borough Council of King's Lynn and West Norfolk in the `local-authority-eng` register. 
 
 *Note: You must have the exact field value of the unique identifier for the record to get a match from the register. For example, in the `local-authority-eng` register, the field value of the unique identifier (the three-letter code for the county council) must be in capital letters.*
 
@@ -132,7 +132,7 @@ Example response:
 }
 ```
 
-### <a name="record-entries">`GET /records/{field-value}/entries`</a>
+### <a name="record-entries">`GET /records/{key}/entries`</a>
 
 Get all entries for a single record.
 
@@ -169,7 +169,7 @@ You can then download the latest item, for example entry 204 in the above exampl
 
 ### `GET /records/{field-name}/{field-value}`
 
-Find all records that share a field-value for a particular field. For example, all local authorities marked as county councils from the `local-authority-eng` register. 
+Get all records that share a field-value for a particular field. For example, all local authorities marked as county councils from the `local-authority-eng` register. 
 
 *Note: Results from this API call are paginated. This call will return the first 100 records from the first page of the register. Use `page-size` to define the number of records you want and `page-index` to define the pages you want. The maximum `page-size` is 5000.*
 
@@ -334,7 +334,7 @@ Example response:
 
 ### `GET /entries/{entry-number}`
 
-Find a specific entry from a register. For example, an update to the record for the New Forest District Council in the `local-authority-eng` register. An entry can include multiple items, which will return in a list of `item-hash`
+Get a specific entry from a register. For example, an update to the record for the New Forest District Council in the `local-authority-eng` register. An entry can include multiple items, which will return in a list of `item-hash`
 
 Example URL: `https://local-authority-eng.register.gov.uk/entries/204`
 
@@ -358,7 +358,7 @@ Example response:
 
 ### <a name="items">`GET /items/{item-hash}`</a>
 
-Find a specific item within a register.
+Get a specific item within a register.
 
 Example URL: `https://local-authority-eng.register.gov.uk/items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31`
 Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31 --header 'Accept: application/json'`

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -6,7 +6,7 @@ Example request: `https://local-authority-eng.register.gov.uk/register`
 
 Download a full new copy of the register by using [the `GET /download-register` endpoint](#download).
 
-Download all updates for one record by [using the `GET /records/{field-value}/entries` endpoint](#record-entries):
+Download all updates for one record according to a particular key by [using the `GET /records/{key}/entries` endpoint](#get-record-key-entries):
 
 Example URL: `https://local-authority-eng.register.gov.uk/records/KIN/entries`
 


### PR DESCRIPTION
Assuming this is done properly, my feeling is we should use the term "key" rather than "primary key" (as long as this is valid) 