### PR TITLE
Fix typo in code snippet

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -165,7 +165,7 @@ Example response:
 ]
 ```
 
-You can then download the latest item, for example entry 204 in the above example. Follow the [guidance for downloading items](#items).
+You can then download the latest item. For example, entry 265 in the above code snippet. Follow the [guidance for downloading items](#items).
 
 ### `GET /records/{field-name}/{field-value}`
 


### PR DESCRIPTION
Also improves language slightly; removes "example" word redundancy 