### PR TITLE
Use master of govuk_tech_docs until a new release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
-gem 'govuk_tech_docs', '~> 1.3'
+gem 'govuk_tech_docs', github: 'alphagov/tech-docs-gem', branch: 'master'
 
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,20 @@
+GIT
+  remote: git://github.com/alphagov/tech-docs-gem.git
+  revision: ba619c71e0b303dff767549b1e78c773aa4a3b03
+  branch: master
+  specs:
+    govuk_tech_docs (1.3.0)
+      activesupport
+      chronic (~> 0.10.2)
+      middleman (~> 4.0)
+      middleman-autoprefixer (~> 2.7.0)
+      middleman-compass (>= 4.0.0)
+      middleman-livereload
+      middleman-sprockets (~> 4.0.0)
+      middleman-syntax (~> 3.0.0)
+      nokogiri
+      redcarpet (~> 3.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -36,22 +53,11 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.2.6)
+    eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.1.3)
     ffi (1.9.23)
-    govuk_tech_docs (1.3.0)
-      activesupport
-      chronic (~> 0.10.2)
-      middleman (~> 4.0)
-      middleman-autoprefixer (~> 2.7.0)
-      middleman-compass (>= 4.0.0)
-      middleman-livereload
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.0.0)
-      nokogiri
-      redcarpet (~> 3.3.2)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -158,7 +164,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs (~> 1.3)
+  govuk_tech_docs!
   therubyracer
   tzinfo-data
   wdm (~> 0.1.0)


### PR DESCRIPTION
We want this https://github.com/alphagov/tech-docs-gem/commit/ba619c71e0b303dff767549b1e78c773aa4a3b03 so until they do a release we are pointing at master