### PR TITLE
set cache control header

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,3 +1,4 @@
+root: build 
 http_strict_transport_security: true
 http_strict_transport_security_include_subdomains: true
-
+location_include: includes/*.conf

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,6 @@
 applications:
 - name: registers-docs
   memory: 64M
-  path: ./build
   buildpack: staticfile_buildpack
   routes:
     - route: docs.registers.service.gov.uk

--- a/nginx/conf/includes/custom_header.conf
+++ b/nginx/conf/includes/custom_header.conf
@@ -1,0 +1,1 @@
+add_header Cache-Control "private, max-age=60";


### PR DESCRIPTION
Previously we did not set any cache headers so were subject to the cloudfront default 24 hour TTL. 

This sets a `max-age` of `60` on everything. (Note I think we could introduce asset hashing and set long cache times for assets but this would be a separate task.)