### PR TITLE
Reorganisation of API reference

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -1,8 +1,6 @@
 ## <a name="apireference">API reference</a>
 
-### <a name="get-register">View information about a register</a>
-
-Endpoint: `GET /register/`
+### <a name="getregister">`GET /register`</a>	
 
 ```http
 GET /register/ HTTP/1.1
@@ -38,9 +36,7 @@ Content-Type: application/json
 }
 ```
 
-### <a name="get-records">Get all records from a register</a>
-
-Endpoint: `GET /records/`
+### <a name="get-records">`GET /records/`</a>
 
 Parameters: 
 * `page-index` (Optional): Collection page number. Defaults to 1.
@@ -106,9 +102,7 @@ Link: <?page-index=2&page-size=3>; rel="next"
 }
 ```
 
-### <a name="get-records-key">Get a specific record within a register based on a particular key</a>
-
-Endpoint: `GET /records/{key}/`
+### <a name="get-records-key">`GET /records/{key}/`</a>
 
 Parameters: 
 * `{key}` (Required): A unique UTF-8 string which identifies something in a register.
@@ -142,9 +136,7 @@ Content-Type: application/json
 }
 ```
 
-### <a name="get-records-key-entries">Get all entries for a single record based on a particular key</a>
-
-Endpoint: `GET /records/{key}/entries/`
+### <a name="get-records-key-entries">`GET /records/{key}/entries/`</a>
 
 Parameters: 
 * `{key}` (Required): A unique UTF-8 string which identifies something in a register.
@@ -182,9 +174,7 @@ Content-Type: application/json
 ]
 ```
 
-### <a name="get-records-field-name-field-value">Get all records that share a `field-value` for a particular `field-name`</a>
-
-Endpoint: `GET /records/{field-name}/{field-value}/`
+### <a name="get-records-field-name-field-value">`GET /records/{field-name}/{field-value}/`</a>
 
 Parameters: 
 * `{field-name}` (Required): Field name. 
@@ -249,9 +239,7 @@ Link: <?page-index=2&page-size=3>; rel="next"
    },
 ```
 
-### <a name="get-entries">Get all entries from a register</a>
-
-Endpoint: `GET /entries/`
+### <a name="get-entries">`GET /entries/`</a>
 
 Parameters: 
 * start (Optional): Collection page number. Defaults to 1.
@@ -364,9 +352,7 @@ Link: <?start=101&limit=100>; rel="next"
 ]
 ```
 
-### <a name="get-entries-entry-number">Get a specific entry from a register</a>
-
-Endpoint: `GET /entries/{entry-number}/`
+### <a name="get-entries-entry-number">`GET /entries/{entry-number}/`</a>
 
 ```http
 GET /entries/{entry-number}/ HTTP/1.1
@@ -392,9 +378,7 @@ Content-Type: application/json
 ]
 ```
 
-### <a name="items">Get a specific item within a register</a>
-
-Endpoint: `GET /items/{item-hash}/`
+### <a name="items">`GET /items/{item-hash}/`</a>
 
 ```http
 GET /items/{item-hash}/ HTTP/1.1
@@ -416,9 +400,7 @@ Content-Type: application/json
 }
 ```
 
-### <a name="items">Download the full contents of the register in a ZIP file</a>
-
-Endpoint: `GET /download-register/`
+### <a name="items">`GET /download-register/`</a>
 
 ```http
 GET /download-register/ HTTP/1.1

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -176,7 +176,7 @@ Content-Type: application/json
 ]
 ```
 
-### <a name="get-records-field-name-field-value">Get all records that share a `{field-value}` for a particular field (`{field-name}`)</a>
+### <a name="get-records-field-name-field-value">Get all records that share a `field-value` for a particular `field-name`</a>
 
 Endpoint: `GET /records/{field-name}/{field-value}/`
 

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -4,15 +4,15 @@
 
 Endpoint: `GET /register/`
 
-```
-GET /register/ HTTP/2
+```http
+GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
 
 {
@@ -43,20 +43,20 @@ Content-Type: application/json
 Endpoint: `GET /records/`
 
 Parameters: 
-* page-index (Optional): Collection page number. Defaults to 1.
-* page-size (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
+* `page-index` (Optional): Collection page number. Defaults to 1.
+* `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
-```
-GET /records/ HTTP/2
+```http
+GET /records/?page-index=1&page-size=3 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
-Link: <?page-index=1&page-size=3>
+Link: <?page-index=2&page-size=3>; rel="next"
 
 {  
    "KIN":{  
@@ -110,15 +110,18 @@ Link: <?page-index=1&page-size=3>
 
 Endpoint: `GET /records/{key}/`
 
-```
-GET /records/{key} HTTP/2
+Parameters: 
+* `{key}` (Required): A unique UTF-8 string which identifies something in a register.
+
+```http
+GET /records/KIN HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
 
 {
@@ -143,15 +146,18 @@ Content-Type: application/json
 
 Endpoint: `GET /records/{key}/entries/`
 
-```
-GET /records/{key}/entries/ HTTP/2
+Parameters: 
+* `{key}` (Required): A unique UTF-8 string which identifies something in a register.
+
+```http
+GET /records/KIN/entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
 
 [
@@ -181,20 +187,22 @@ Content-Type: application/json
 Endpoint: `GET /records/{field-name}/{field-value}/`
 
 Parameters: 
-* page-index (Optional): Collection page number. Defaults to 1.
-* page-size (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
+* `{field-name}` (Required): Field name. 
+* `{field-value}` (Required): Field value. 
+* `page-index` (Optional): Collection page number. Defaults to 1.
+* `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
-```
-GET /records/{field-name}/{field-value}/ HTTP/2
+```http
+GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
-Link: <?page-index=1&page-size=3>
+Link: <?page-index=2&page-size=3>; rel="next"
 
 {  
    "NTH":{  
@@ -246,20 +254,21 @@ Link: <?page-index=1&page-size=3>
 Endpoint: `GET /entries/`
 
 Parameters: 
-* start (Optional): Collection page number. Defaults to ?.
-* limit (Optional): Collection page size. Defaults to ?. Maximum is ?. 
+* start (Optional): Collection page number. Defaults to 1.
+* limit (Optional): Collection page size. Defaults to 100. Maximum is PLACEHOLDER. 
 
-```
-GET /entries/ HTTP/2
+```http
+GET /entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
-Link: <?start=1&limit=10>
+Link: <?start=101&limit=100>; rel="next"
+
 
 [  
    {  
@@ -359,15 +368,15 @@ Link: <?start=1&limit=10>
 
 Endpoint: `GET /entries/{entry-number}/`
 
-```
-GET /entries/{entry-number}/ HTTP/2
+```http
+GET /entries/{entry-number}/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
 
 [
@@ -387,15 +396,15 @@ Content-Type: application/json
 
 Endpoint: `GET /items/{item-hash}/`
 
-```
-GET /items/{item-hash}/ HTTP/2
+```http
+GET /items/{item-hash}/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
+```http
+HTTP/1.1 200
 Content-Type: application/json
 
 {
@@ -411,22 +420,13 @@ Content-Type: application/json
 
 Endpoint: `GET /download-register/`
 
-```
-GET /download-register/ HTTP/2
+```http
+GET /download-register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-```
-HTTP/2 200
-Content-Type: application/json
-
-
-> This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.
-
-Example URL: `https://local-authority-eng.register.gov.uk/download-register`
-
-Example request: `curl -o localauthorityeng.zip --request GET --url https://local-authority-eng.register.gov.uk/download-register  --header 'Authorization: YOUR-API-KEY-HERE'`
+This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.
 
 

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -1,6 +1,6 @@
 ## <a name="apireference">API reference</a>
 
-### <a name="getregister">`GET /register`</a>	
+### <a name="getregister">`GET /register/`</a>	
 
 ```http
 GET /register/ HTTP/1.1

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -2,7 +2,7 @@
 
 ### <a name="getregister">`GET /register/`</a>	
 
-View information about a register.
+Get information about a register.
 
 ```http
 GET /register/ HTTP/1.1

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -255,7 +255,7 @@ Endpoint: `GET /entries/`
 
 Parameters: 
 * start (Optional): Collection page number. Defaults to 1.
-* limit (Optional): Collection page size. Defaults to 100. Maximum is PLACEHOLDER. 
+* limit (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
 ```http
 GET /entries/ HTTP/1.1

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -2,6 +2,8 @@
 
 ### <a name="getregister">`GET /register/`</a>	
 
+View information about a register.
+
 ```http
 GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
@@ -37,6 +39,8 @@ Content-Type: application/json
 ```
 
 ### <a name="get-records">`GET /records/`</a>
+
+Get all records from a register.
 
 Parameters: 
 * `page-index` (Optional): Collection page number. Defaults to 1.
@@ -104,6 +108,8 @@ Link: <?page-index=2&page-size=3>; rel="next"
 
 ### <a name="get-records-key">`GET /records/{key}/`</a>
 
+Get a specific record within a register based on a particular key.
+
 Parameters: 
 * `{key}` (Required): A unique UTF-8 string which identifies something in a register.
 
@@ -137,6 +143,8 @@ Content-Type: application/json
 ```
 
 ### <a name="get-records-key-entries">`GET /records/{key}/entries/`</a>
+
+Get all entries for a single record based on a particular key.
 
 Parameters: 
 * `{key}` (Required): A unique UTF-8 string which identifies something in a register.
@@ -175,6 +183,8 @@ Content-Type: application/json
 ```
 
 ### <a name="get-records-field-name-field-value">`GET /records/{field-name}/{field-value}/`</a>
+
+Get all records that share a `field-value` for a particular `field-name`.
 
 Parameters: 
 * `{field-name}` (Required): Field name. 
@@ -240,6 +250,8 @@ Link: <?page-index=2&page-size=3>; rel="next"
 ```
 
 ### <a name="get-entries">`GET /entries/`</a>
+
+Get all entries from a register.
 
 Parameters: 
 * start (Optional): Collection page number. Defaults to 1.
@@ -354,6 +366,8 @@ Link: <?start=101&limit=100>; rel="next"
 
 ### <a name="get-entries-entry-number">`GET /entries/{entry-number}/`</a>
 
+Get a specific entry from a register.
+
 ```http
 GET /entries/{entry-number}/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
@@ -380,6 +394,8 @@ Content-Type: application/json
 
 ### <a name="items">`GET /items/{item-hash}/`</a>
 
+Get a specific item within a register.
+
 ```http
 GET /items/{item-hash}/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
@@ -401,6 +417,8 @@ Content-Type: application/json
 ```
 
 ### <a name="items">`GET /download-register/`</a>
+
+Download the full contents of the register in a ZIP file.
 
 ```http
 GET /download-register/ HTTP/1.1

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -245,6 +245,10 @@ Link: <?page-index=1&page-size=3>
 
 Endpoint: `GET /entries/`
 
+Parameters: 
+* start (Optional): Collection page number. Defaults to ?.
+* limit (Optional): Collection page size. Defaults to ?. Maximum is ?. 
+
 ```
 GET /entries/ HTTP/2
 Host: local-authority-eng.register.gov.uk
@@ -255,6 +259,7 @@ Authorization: YOUR-API-KEY-HERE
 ```
 HTTP/2 200
 Content-Type: application/json
+Link: <?start=1&limit=10>
 
 [  
    {  

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -141,7 +141,7 @@ Content-Type: application/json
 
 ### <a name="get-records-key-entries">Get all entries for a single record based on a particular key</a>
 
-Endpoint: `GET /records/{key}/entries`
+Endpoint: `GET /records/{key}/entries/`
 
 ```
 GET /records/{key}/entries/ HTTP/2
@@ -178,7 +178,7 @@ Content-Type: application/json
 
 ### <a name="get-records-field-name-field-value">Get all records that share a `{field-value}` for a particular field (`{field-name}`)</a>
 
-Endpoint: `GET /records/{field-name}/{field-value}`
+Endpoint: `GET /records/{field-name}/{field-value}/`
 
 Parameters: 
 * page-index (Optional): Collection page number. Defaults to 1.

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -1,22 +1,20 @@
 ## <a name="apireference">API reference</a>
 
-### <a name="getregister">`GET /register`</a>
+### <a name="get-register">View information about a register</a>
 
-View information about a register, including:  
-
-* the internet domain the register is on
-* when the register was last updated
-* how many entries and records the register contains
-
-You can check the entry number you have locally is up to date with the register by comparing the value of `total-entries` for each. 
-
-Example URL: `https://local-authority-eng.register.gov.uk/register`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/register/ --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Endpoint: `GET /register/`
 
 ```
+GET /register/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 {
   "domain": "register.gov.uk",
   "total-records": 354,
@@ -40,19 +38,26 @@ Example response:
 }
 ```
 
-### `GET /records`
+### <a name="get-records">Get all records from a register</a>
 
-Get all records from the register. For example, all of the English local authorities from the `local-authority-eng` register.
+Endpoint: `GET /records/`
 
-> Results from this API call are paginated. This call will return the first 100 records from the first page of the register. Use `page-size` to define the number of records you want and `page-index` to define the pages you want. The maximum `page-size` is 5000.
-
-Example URL: `https://local-authority-eng.register.gov.uk/records`
-
-Example request: `curl --request GET --url 'https://local-authority-eng.register.gov.uk/records?page-index=1&page-size=3' --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Parameters: 
+* page-index (Optional): Collection page number. Defaults to 1.
+* page-size (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
 ```
+GET /records/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+Link: <?page-index=1&page-size=3>
+
 {  
    "KIN":{  
       "index-entry-number":"357",
@@ -101,19 +106,21 @@ Example response:
 }
 ```
 
-### `GET /records/{key}`
+### <a name="get-records-key">Get a specific record within a register based on a particular key</a>
 
-Get a specific record within a register based on a particular key. For example, the record for the Borough Council of King's Lynn and West Norfolk in the `local-authority-eng` register. 
-
-> You must have the exact field value of the unique identifier for the record to get a match from the register. For example, in the `local-authority-eng` register, the field value of the unique identifier (the three-letter code for the county council) must be in capital letters.
-
-Example URL: `https://local-authority-eng.register.gov.uk/records/KIN`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/records/KIN --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Endpoint: `GET /records/{key}/`
 
 ```
+GET /records/{key} HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 {
   "KIN": {
     "index-entry-number": "357",
@@ -132,17 +139,21 @@ Example response:
 }
 ```
 
-### <a name="record-entries">`GET /records/{key}/entries`</a>
+### <a name="get-records-key-entries">Get all entries for a single record based on a particular key</a>
 
-Get all entries for a single record.
-
-Example URL: `https://local-authority-eng.register.gov.uk/records/KIN/entries`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/records/KIN/entries/ --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Endpoint: `GET /records/{key}/entries`
 
 ```
+GET /records/{key}/entries/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 [
   {
     "index-entry-number": "265",
@@ -165,21 +176,26 @@ Example response:
 ]
 ```
 
-You can then download the latest item. For example, entry 265 in the above code snippet. Follow the [guidance for downloading items](#items).
+### <a name="get-records-field-name-field-value">Get all records that share a `{field-value}` for a particular field (`{field-name}`)</a>
 
-### `GET /records/{field-name}/{field-value}`
+Endpoint: `GET /records/{field-name}/{field-value}`
 
-Get all records that share a field-value for a particular field. For example, all local authorities marked as county councils from the `local-authority-eng` register. 
-
-> Results from this API call are paginated. This call will return the first 100 records from the first page of the register. Use `page-size` to define the number of records you want and `page-index` to define the pages you want. The maximum `page-size` is 5000.
-
-Example URL: `https://local-authority-eng.register.gov.uk/records/local-authority-type/CTY`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/records/local-authority-type/CTY --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Parameters: 
+* page-index (Optional): Collection page number. Defaults to 1.
+* page-size (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
 ```
+GET /records/{field-name}/{field-value}/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+Link: <?page-index=1&page-size=3>
+
 {  
    "NTH":{  
       "index-entry-number":"269",
@@ -225,19 +241,21 @@ Example response:
    },
 ```
 
-### `GET /entries`
+### <a name="get-entries">Get all entries from a register</a>
 
-Get all entries from the register. For example, all updates there have ever been to the `local-authority-eng` register.
-
-> Results from this API call are paginated. This call will return the first 100 entries from the first page of the register. Use `limit` to define the maximum number of entries you want and `start` to define the entry number you want to start from (in ascending order).
-
-Example URL: `https://local-authority-eng.register.gov.uk/entries?start=1&limit=10`
-
-Example request: `curl --request GET --url 'https://local-authority-eng.register.gov.uk/entries?start=1&limit=10' --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Endpoint: `GET /entries/`
 
 ```
+GET /entries/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 [  
    {  
       "index-entry-number":"1",
@@ -332,17 +350,21 @@ Example response:
 ]
 ```
 
-### `GET /entries/{entry-number}`
+### <a name="get-entries-entry-number">Get a specific entry from a register</a>
 
-Get a specific entry from a register. For example, an update to the record for the New Forest District Council in the `local-authority-eng` register. An entry can include multiple items, which will return in a list of `item-hash`
-
-Example URL: `https://local-authority-eng.register.gov.uk/entries/204`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/entries/204/ --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Endpoint: `GET /entries/{entry-number}/`
 
 ```
+GET /entries/{entry-number}/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 [
   {
     "index-entry-number": "204",
@@ -356,17 +378,21 @@ Example response:
 ]
 ```
 
-### <a name="items">`GET /items/{item-hash}`</a>
+### <a name="items">Get a specific item within a register</a>
 
-Get a specific item within a register.
-
-Example URL: `https://local-authority-eng.register.gov.uk/items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31`
-
-Example request: `curl --request GET --url https://local-authority-eng.register.gov.uk/items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31 --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'`
-
-Example response:
+Endpoint: `GET /items/{item-hash}/`
 
 ```
+GET /items/{item-hash}/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 {
   "local-authority-type": "UA",
   "official-name": "Bath and North East Somerset Council",
@@ -376,9 +402,21 @@ Example response:
 }
 ```
 
-### <a name="download">`GET /download-register`</a>
+### <a name="items">Download the full contents of the register in a ZIP file</a>
 
-Download the full contents of the register in a ZIP file.
+Endpoint: `GET /download-register/`
+
+```
+GET /download-register/ HTTP/2
+Host: local-authority-eng.register.gov.uk
+Accept: application/json
+Authorization: YOUR-API-KEY-HERE
+```
+
+```
+HTTP/2 200
+Content-Type: application/json
+
 
 > This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.
 


### PR DESCRIPTION
Fairly significant reorganisation of the API reference information. Removes use of `curl` to make not only platform-agnostic but also tool-agnostic, and aligns better with specification. 

Should also be more developer-friendly. Feedback welcomed, as ever.

Having some problems with consistency in nomenclature and curly braces, for example with: 

> Get all records that share a `field-value` for a particular field-name

Also just to note that if this PR is approved in principle then we (I) will have to edit the quick start guide's links to match some new tags; the only reason I haven't done that yet is because I mainly want to use this to gather early feedback on this change for the time being. 

Please also see the notes below. 
