### PR TITLE
Update content types to be consistent with the implementation

### DIFF
--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -45,10 +45,10 @@ Choose a response format by adding the appropriate suffix to the request URL:
 | Format | Suffix | Media type |
 |--------|--------|------------|
 | JSON | .json | application/json |
-| YAML | .yaml | text/ yaml |
+| YAML | .yaml | text/yaml |
 | CSV | .csv | text/csv |
-| TSV | .tsv | text/tsv |
-| Turtle | .ttl | text/ttl |
+| TSV | .tsv | text/tab-separated-values |
+| Turtle | .ttl | text/turtle |
 
 For example: 
 


### PR DESCRIPTION
### Context
When I tried specifying the content types in the documentation with an `Accept` header, `text/tsv` and `text/tff` return 406 responses (406 = "not acceptable").

### Changes proposed in this pull request
The supported media types are defined in the implmentation here:
https://github.com/openregister/openregister-java/blob/master/src/main/java/uk/gov/register/views/representations/ExtraMediaType.java

These are the correct values according to
- https://www.w3.org/TR/turtle/#sec-mime
- https://www.iana.org/assignments/media-types/text/tab-separated-values

### Guidance to review
