### PR TITLE
Remove brackets around (s) in QS guide section

### DIFF
--- a/source/documentation/getting_started/quick_start.md
+++ b/source/documentation/getting_started/quick_start.md
@@ -12,7 +12,7 @@ You should include your key in all requests using the `Authorization` header:
 
 `curl https://country.register.gov.uk/records/GB.json --header 'Authorization: YOUR-API-KEY-HERE'`
 
-### Find the base URL for register(s) 
+### Find the base URL for registers 
 
 Find the base URL for each register on its API inspector. For example, the API inspector for the `local-authority-eng` register is located at `https://local-authority-eng.register.gov.uk/`. 
 


### PR DESCRIPTION
### Context
The anchor is broken without this fix. 

i.e.:

http://localhost:4567/quick_start/#find-the-base-url-for-register-s

### Changes proposed in this pull request
> Find the base URLs for register(s) 

to

> Find the base URLs for registers

^ This fixes the anchor

### Guidance to review
N/A