### PR TITLE
Moves error codes section to API reference and renames

### DIFF
--- a/source/documentation/support/support.md
+++ b/source/documentation/support/support.md
@@ -1,13 +1,5 @@
 ## Support
 
-### Error codes
-
-| Error code | Description           |
-|------------|-----------------------|
-| 200        | Ok                    |
-| 404        | Data not found        |
-| 500        | Internal server error |
-
 ### If you cannot find a specific record 
 
 Check you have the correct field value. You must use the exact field value to get a match from the register. 

--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -397,7 +397,7 @@ Content-Type: application/json
 ]
 ```
 
-### <a name="items">`GET /items/{item-hash}/`</a>
+### <a name="get-item-item-hash">`GET /items/{item-hash}/`</a>
 
 Get a specific item within a register.
 
@@ -421,7 +421,7 @@ Content-Type: application/json
 }
 ```
 
-### <a name="items">`GET /download-register/`</a>
+### <a name="get-download-register">`GET /download-register/`</a>
 
 Download the full contents of the register in a ZIP file.
 
@@ -434,4 +434,10 @@ Authorization: YOUR-API-KEY-HERE
 
 This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.
 
+### <a name="http-status-codes">HTTP status codes</a>
 
+| Status code | Description           |
+|------------|-----------------------|
+| 200        | Ok                    |
+| 404        | Data not found        |
+| 500        | Internal server error |


### PR DESCRIPTION
### Context
The error codes are misnamed. One of them isn't an error code, and the more generic 'HTTP status codes' title makes more sense 

### Changes proposed in this pull request
Renames the error codes table and moves it from the support section to the API reference