### PR TITLE
Changes title of 'getting updates' section

### DIFF
--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -1,4 +1,4 @@
-## Getting updates
+## Updating registers
 
 You can find the latest entry number by looking at the register information (use the [`GET /register` endpoint](#get-register)) and comparing the most recent entry number with your own copy.
 


### PR DESCRIPTION
### Context
Whilst we wait for content review on https://github.com/alphagov/registers-tech-docs/pull/96 this probably makes sense to change since it might be ambiguous what's actually meant by 'Getting updates'

### Changes proposed in this pull request
Changes title of 'Getting updates' section to 'Updating registers'

