### PR TITLE
Introduce 'Example request', 'Example response'

### DIFF
--- a/source/documentation/using_the_api/api_reference.md
+++ b/source/documentation/using_the_api/api_reference.md
@@ -4,12 +4,16 @@
 
 Get information about a register.
 
+Example request:
+
 ```http
 GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -47,12 +51,16 @@ Parameters:
 * `page-index` (Optional): Collection page number. Defaults to 1.
 * `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
+Example request:
+
 ```http
 GET /records/?page-index=1&page-size=3 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -115,12 +123,16 @@ Parameters:
 
 * `key` (Required): A unique UTF-8 string which identifies something in a register.
 
+Example request:
+
 ```http
 GET /records/KIN HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -152,12 +164,16 @@ Parameters:
 
 * `key` (Required): A unique UTF-8 string which identifies something in a register.
 
+Example request:
+
 ```http
 GET /records/KIN/entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -196,12 +212,16 @@ Parameters:
 * `page-index` (Optional): Collection page number. Defaults to 1.
 * `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
+Example request:
+
 ```http
 GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -262,12 +282,16 @@ Parameters:
 * `start` (Optional): Collection page number. Defaults to 1.
 * `limit` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
+Example request:
+
 ```http
 GET /entries/?start=1&limit=10 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -373,12 +397,16 @@ Link: <?start=11&limit=10>; rel="next"
 
 Get a specific entry from a register.
 
+Example request:
+
 ```http
 GET /entries/204/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -402,12 +430,16 @@ Content-Type: application/json
 
 Get a specific item within a register.
 
+Example request:
+
 ```http
 GET /items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200
@@ -425,6 +457,8 @@ Content-Type: application/json
 ### <a name="get-download-register">`GET /download-register/`</a>
 
 Download the full contents of the register in a ZIP file.
+
+Example request:
 
 ```http
 GET /download-register/ HTTP/1.1


### PR DESCRIPTION

### Context
API reference lacks explicit labels to indicate requests/responses and that they are examples

### Changes proposed in this pull request
Makes explicit that requests and responses in the API reference are in fact those things, and that they are examples (in the absence of a real API Explorer)

