### PR TITLE
Spinoff of 'Getting updates v3' - alternative version 

### DIFF
--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -6,10 +6,10 @@ You can regularly compare this value with new queries to a register to see if th
 
 ### Return all new entries since your last update
 
-You can use the [`GET /entries/` endpoint](#getentries) to return specific entries to a register. This takes the parameters `start` and `limit`. 
+You can use the [`GET /entries/` endpoint](#getentries) to return specific entries to a register. 
 
 For example, your last highest entry number from the `government-organisation` register could
-be 750. You could then make this request to find out if there are any new entries:
+be 750. To find out if there are any new entries, you could make this request:
 
 ```http
 GET /entries/?start=751 HTTP/1.1
@@ -18,7 +18,7 @@ Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-If you receive a response, you'll know there are updates.
+If you get a response that's not empty, you'll know there are updates.
 
 You should also look at the `Link` header. The response to the example would contain this header:
 
@@ -28,9 +28,7 @@ Content-Type: application/json
 Link: <?start=850&limit=100>; rel="next",<?start=650&limit=100>; rel="previous"
 ```
 
-Here, there are more than 100 new entries since the last update, and `rel="next"` shows that these have been paginated. 
-
-In this situation, you could set the `limit` parameter higher. You could also make new requests, increasing the value of `start` each time, until a `Link` header is returned without `rel="next"`.
+Here, there are more than 100 new entries since the last update. In this situation, you can follow the links in `rel="next"` until the `Link` header no longer contains one. 
 
 ### See what data is in each entry 
 
@@ -38,6 +36,3 @@ You can use the [`GET /items/{item-hash}` endpoint](#items) on the value in
 the `item-hash` property 
 
 You can read more about [this and how entries, items and records relate](how-entries-items-and-records-relate).
-
-
-

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -20,7 +20,7 @@ Authorization: YOUR-API-KEY-HERE
 
 If you receive a response, you'll know there are updates.
 
-You should also look at the `Link` header. In the example response:
+You should also look at the `Link` header. The response to the example would contain this header:
 
 ```http
 HTTP/1.1 200
@@ -28,9 +28,9 @@ Content-Type: application/json
 Link: <?start=850&limit=100>; rel="next",<?start=650&limit=100>; rel="previous"
 ```
 
-Here, there are more than 100 new entries since the last update, as shown by `rel="next"`. 
+Here, there are more than 100 new entries since the last update, and `rel="next"` shows that these have been paginated. 
 
-In this situation, you could set the `limit` parameter higher. You could also make new requests, increasing the value of `start` each time, until a `Link` header is not returned with `rel="next"`.
+In this situation, you could set the `limit` parameter higher. You could also make new requests, increasing the value of `start` each time, until a `Link` header is returned without `rel="next"`.
 
 ### See what data is in each entry 
 

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -37,30 +37,9 @@ In this situation, you can set the `limit` parameter higher. You can also make n
 ### See what data is in each entry 
 
 You can use the [`GET /items/{item-hash}` endpoint](#items) on the value in
-the `item-hash` property. 
+the `item-hash` property 
 
-Following the previous example, you could make a request using the
-`item-hash` value in entry 208:
-
-```http
-GET /items/sha-256:f89f36ed8b2a1417237a8e95b810e8ab4ead844277ad7bc7794cb5f83732c976 HTTP/1.1 
-Host: country.register.gov.uk
-Accept: application/json
-Authorization: YOUR-API-KEY-HERE
-```
-
-Example response:
-
-```http
-HTTP/1.1 200
-Content-Type: application/json
-{
-  "country": "SZ",
-  "official-name": "Kingdom of Eswatini",
-  "name": "Eswatini",
-  "citizen-names": "Swazi"
-}
-```
+You can read more about [this and how entries, items and records relate](how-entries-items-and-records-relate).
 
 
 

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -9,9 +9,7 @@ You can regularly compare this value with new queries to a register to see if th
 You can use the [`GET /entries/` endpoint](#getentries) to return specific entries to a register. This takes the parameters `start` and `limit`. 
 
 For example, your last highest entry number from the `government-organisation` register could
-be 750. You could then make a request to find out if there are any new entries. If you receive a response, you'll know there are updates.
-
-Example request:
+be 750. You could then make this request to find out if there are any new entries:
 
 ```http
 GET /entries/?start=751 HTTP/1.1
@@ -20,9 +18,9 @@ Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-You should also look at the `Link` header in the response. 
+If you receive a response, you'll know there are updates.
 
-Example response header:
+You should also look at the `Link` header. In the example response:
 
 ```http
 HTTP/1.1 200
@@ -30,9 +28,9 @@ Content-Type: application/json
 Link: <?start=850&limit=100>; rel="next",<?start=650&limit=100>; rel="previous"
 ```
 
-In the example, there are more than 100 new entries since the last update, as shown by `rel="next"`. 
+Here, there are more than 100 new entries since the last update, as shown by `rel="next"`. 
 
-In this situation, you can set the `limit` parameter higher. You can also make new requests, increasing the value of `start` each time, until you no longer see a `Link` header returned with `rel="next"`.
+In this situation, you could set the `limit` parameter higher. You could also make new requests, increasing the value of `start` each time, until a `Link` header is not returned with `rel="next"`.
 
 ### See what data is in each entry 
 

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -25,7 +25,7 @@ You should also look at the `Link` header. The response to the example would con
 ```http
 HTTP/1.1 200
 Content-Type: application/json
-Link: <?start=850&limit=100>; rel="next",<?start=650&limit=100>; rel="previous"
+Link: <?start=851&limit=100>; rel="next",<?start=651&limit=100>; rel="previous"
 ```
 
 Here, there are more than 100 new entries since the last update. In this situation, you can follow the links in `rel="next"` until the `Link` header no longer contains one. 

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -1,15 +1,14 @@
 ## Getting updates
 
-This guide assumes you know the current highest entry number for your copy of a register. 
+To follow this guidance, you need to know the current highest entry number for your copy of a register. 
 
-You can regularly compare this value with new queries to a register to see if there are any updates.
+If there are new entries to the register, you can query the register to return the new entries.
 
 ### Return all new entries since your last update
 
 You can use the [`GET /entries/` endpoint](#getentries) to return specific entries to a register. 
 
-For example, your last highest entry number from the `government-organisation` register could
-be 750. To find out if there are any new entries, you could make this request:
+For example, your last highest entry number from the `government-organisation` register could be 750. To find out if there are any new entries, you could make this request:
 
 ```http
 GET /entries/?start=751 HTTP/1.1
@@ -18,9 +17,9 @@ Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-If you get a response that's not empty, you'll know there are updates.
+If there are no updates, you will receive an empty response. If there are updates, you will receive the new entries in the response.
 
-You should also look at the `Link` header. The response to the example would contain this header:
+The response to the previous example contains:
 
 ```http
 HTTP/1.1 200
@@ -28,11 +27,12 @@ Content-Type: application/json
 Link: <?start=851&limit=100>; rel="next",<?start=651&limit=100>; rel="previous"
 ```
 
-Here, there are more than 100 new entries since the last update. In this situation, you can follow the links in `rel="next"` until the `Link` header no longer contains one. 
+In this example, there are more than 100 new entries since the last update, as shown by the `Link` header. In this situation, you can follow the links in `rel="next"` until the `Link` header no longer contains that link. 
 
 ### See what data is in each entry 
 
 You can use the [`GET /items/{item-hash}` endpoint](#items) on the value in
-the `item-hash` property 
+the `item-hash` property. 
 
 You can read more about [this and how entries, items and records relate](how-entries-items-and-records-relate).
+

--- a/source/documentation/using_the_api/getting_updates.md
+++ b/source/documentation/using_the_api/getting_updates.md
@@ -6,57 +6,33 @@ You can regularly compare this value with new queries to a register to see if th
 
 ### Return all new entries since your last update
 
-You can use the [`GET /entries/` endpoint](#getentries) with the `start` and
-`limit` parameters to return specific entries to a register. 
+You can use the [`GET /entries/` endpoint](#getentries) to return specific entries to a register. This takes the parameters `start` and `limit`. 
 
-For example, your last highest entry number from the `country` register could
-be 205. You could then use the following request to find out if there are any
-new entries:
+For example, your last highest entry number from the `government-organisation` register could
+be 750. You could then make a request to find out if there are any new entries. If you receive a response, you'll know there are updates.
+
+Example request:
 
 ```http
-GET /entries/?start=206 HTTP/1.1
-Host: country.register.gov.uk
+GET /entries/?start=751 HTTP/1.1
+Host: goverment-organisation.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
 
-Example response:
+You should also look at the `Link` header in the response. 
+
+Example response header:
 
 ```http
 HTTP/1.1 200
 Content-Type: application/json
-Link <?start=106&limit=100>; rel="previous"
-
-[
-  {
-    "index-entry-number": "206",
-    "entry-number": "206",
-    "entry-timestamp": "2017-03-29T14:22:30Z",
-    "key": "GM",
-    "item-hash": [
-      "sha-256:0429375c4fb403288ef816e5dd38a24f192e35b8f55e40cc6266eb25eaef77b1"
-    ]
-  },
-  {
-    "index-entry-number": "207",
-    "entry-number": "207",
-    "entry-timestamp": "2017-10-25T09:52:52Z",
-    "key": "CI",
-    "item-hash": [
-      "sha-256:b3ca21b3b3a795ab9cd1d10f3d447947328406984f8a461b43d9b74b58cccfe8"
-    ]
-  },
-  {
-    "index-entry-number": "208",
-    "entry-number": "208",
-    "entry-timestamp": "2018-06-13T13:54:40Z",
-    "key": "SZ",
-    "item-hash": [
-      "sha-256:f89f36ed8b2a1417237a8e95b810e8ab4ead844277ad7bc7794cb5f83732c976"
-    ]
-  }
-]
+Link: <?start=850&limit=100>; rel="next",<?start=650&limit=100>; rel="previous"
 ```
+
+In the example, there are more than 100 new entries since the last update, as shown by `rel="next"`. 
+
+In this situation, you can set the `limit` parameter higher. You can also make new requests, increasing the value of `start` each time, until you no longer see a `Link` header returned with `rel="next"`.
 
 ### See what data is in each entry 
 
@@ -67,7 +43,7 @@ Following the previous example, you could make a request using the
 `item-hash` value in entry 208:
 
 ```http
-GET /items/sha-256:f89f36ed8b2a1417237a8e95b810e8ab4ead844277ad7bc7794cb5f83732c976
+GET /items/sha-256:f89f36ed8b2a1417237a8e95b810e8ab4ead844277ad7bc7794cb5f83732c976 HTTP/1.1 
 Host: country.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
@@ -86,26 +62,5 @@ Content-Type: application/json
 }
 ```
 
-### If you have more updates than the value of `limit` 
-
-[The `limit` parameter defaults to 100, and its maximum value is
-5000](#get-entries). In the previous example, `limit` was 100. Here, if there
-were more than 100 new entries since your last update, you would not get them
-all. 
-
-In this situation, you could set the `limit` parameter higher, but you may
-still need to look at the `Link` header returned. If there are more new
-entries than the value of `limit`, you'll see `rel="next"`. For example:
-
-```http
-HTTP/1.1 200
-Content-Type: application/json
-Link <?start=306&limit=100>; rel="next", <?start=106&limit=100>; rel="previous"
-
-...
-```
-
-You could then make new requests, increasing the value of `start` each time, until
-you no longer see a `Link` header returned with `rel="next"`.
 
 


### PR DESCRIPTION
### Context
@arnau made some recommendations based on not reinforcing the use of the `limit` parameter. This is a suggested alternative to https://github.com/alphagov/registers-tech-docs/pull/105 to get around that. 

### Changes proposed in this pull request
- Reorganises accordingly (simplifies and removes some content)

- Also adds some accidentally omitted content

- Uses the `government-organisation` register in the examples instead of the `country` register, since it's updated more often

- Changes example to give both `next` and `previous` in the `Link` header
