### PR TITLE
Change precedence of links in API reference left-hand nav

### DIFF
--- a/source/api_reference/get_download_register/index.html.md.erb
+++ b/source/api_reference/get_download_register/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GET /download-register/
-weight: 80
+weight: 90
 ---
 
 # <a name="get-download-register">`GET /download-register/`</a>

--- a/source/api_reference/http_status_codes/index.html.md.erb
+++ b/source/api_reference/http_status_codes/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: HTTP status codes
-weight: 90
+weight: 100
 ---
 
 # <a name="http-status-codes">HTTP status codes</a>

--- a/source/api_reference/rate_limits/index.html.md.erb
+++ b/source/api_reference/rate_limits/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Rate limits
-weight: 100
+weight: 110
 ---
 
 


### PR DESCRIPTION
### Context
The links are in the wrong order at https://docs.registers.service.gov.uk/api_reference/#api-reference

### Changes proposed in this pull request
Fixes to the parameter that determines order in each of the offending files 