### PR TITLE
run 2 instances

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: registers-docs
   memory: 64M
+  instances: 2
   buildpack: staticfile_buildpack
   routes:
     - route: docs.registers.service.gov.uk


### PR DESCRIPTION
### Context
production apps should have more than one instance as per [production checklist](https://docs.cloud.service.gov.uk/deploying_apps.html#production-checklist).

### Changes proposed in this pull request
run 2 instances

### Guidance to review
should deploy successfully through travis ci.
