### PR TITLE
Change structure of tech docs to improve landing page / user journeys for users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
-gem 'govuk_tech_docs', '~> 1.5.0'
+gem 'govuk_tech_docs', :git => 'https://github.com/alphagov/tech-docs-gem.git', ref:'de0c518324f01cbb107fcd5dc685a44cdca4ac00'
+gem 'middleman-search', git: 'git://github.com/alphagov/middleman-search.git'
 
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,30 @@
+GIT
+  remote: git://github.com/alphagov/middleman-search.git
+  revision: 50d072378c6f92a78ea02fed366ec6453aea8552
+  specs:
+    middleman-search (0.10.0)
+      execjs (~> 2.6)
+      middleman-core (>= 3.2)
+      nokogiri (~> 1.6)
+
+GIT
+  remote: https://github.com/alphagov/tech-docs-gem.git
+  revision: de0c518324f01cbb107fcd5dc685a44cdca4ac00
+  ref: de0c518324f01cbb107fcd5dc685a44cdca4ac00
+  specs:
+    govuk_tech_docs (1.5.0)
+      activesupport
+      chronic (~> 0.10.2)
+      middleman (~> 4.0)
+      middleman-autoprefixer (~> 2.7.0)
+      middleman-compass (>= 4.0.0)
+      middleman-livereload
+      middleman-search
+      middleman-sprockets (~> 4.0.0)
+      middleman-syntax (~> 3.0.0)
+      nokogiri
+      redcarpet (~> 3.3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -41,18 +68,6 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.1.3)
     ffi (1.9.25)
-    govuk_tech_docs (1.5.0)
-      activesupport
-      chronic (~> 0.10.2)
-      middleman (~> 4.0)
-      middleman-autoprefixer (~> 2.7.0)
-      middleman-compass (>= 4.0.0)
-      middleman-livereload
-      middleman-search
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.0.0)
-      nokogiri
-      redcarpet (~> 3.3.2)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -110,10 +125,6 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    middleman-search (0.10.0)
-      middleman-core (>= 3.2)
-      nokogiri (~> 1.6)
-      therubyracer (~> 0.12.2)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -163,10 +174,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk_tech_docs (~> 1.5.0)
+  govuk_tech_docs!
+  middleman-search!
   therubyracer
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,10 @@
 ---
 applications:
-- name: registers-docs
+- name: registers-docs-testing
   memory: 64M
   instances: 2
   buildpack: staticfile_buildpack
   routes:
-    - route: docs.registers.service.gov.uk
+    - route: registers-docs-testing-2.cloudapps.digital
   services:
     - logit-ssl-drain

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,13 +1,15 @@
 ---
-title: GOV.UK Registers quick start guide
-weight: 10
+title: GOV.UK Registers technical documentation
+weight: 05
 ---
 
-# GOV.UK Registers<br /> quick start guide
+# GOV.UK Registers technical documentation 
 
-<%= partial 'documentation/quick_start_guide/generate_an_api_key' %>
-<%= partial 'documentation/quick_start_guide/authenticate_with_your_api_key' %>
-<%= partial 'documentation/quick_start_guide/find_the_base_url_for_registers' %>
-<%= partial 'documentation/quick_start_guide/choose_an_endpoint' %>
-<%= partial 'documentation/quick_start_guide/choose_a_response_format' %>
-<%= partial 'documentation/quick_start_guide/pagination' %>
+In this documentation, you can read about:
+
+* getting started [with the GOV.UK Registers API](#quick-start-guide)
+* the components [that make up registers](#the-components-of-a-register)
+* how registers [can be linked](#linked-registers)
+* making sure the [data you use is up to date](#getting-updates)
+* reference information [about the GOV.UK Registers API](#api-reference)
+* how to [contact us if you need support](#support)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 05
 
 In this documentation, you can read about:
 
-* getting started [with the GOV.UK Registers API](#quick-start-guide)
+* how to get started [with the GOV.UK Registers API](#quick-start-guide)
 * the components [that make up registers](#the-components-of-a-register)
 * how registers [can be linked](#linked-registers)
 * making sure the [data you use is up to date](#getting-updates)

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: Quick start guide
+weight: 10
+---
+
+# Quick start guide
+
+<%= partial 'documentation/quick_start_guide/generate_an_api_key' %>
+<%= partial 'documentation/quick_start_guide/authenticate_with_your_api_key' %>
+<%= partial 'documentation/quick_start_guide/find_the_base_url_for_registers' %>
+<%= partial 'documentation/quick_start_guide/choose_an_endpoint' %>
+<%= partial 'documentation/quick_start_guide/choose_a_response_format' %>
+<%= partial 'documentation/quick_start_guide/pagination' %>


### PR DESCRIPTION
### Context
At the moment we don't have the best route for user journeys into the technical documentation, and some feedback we've received indicates that users aren't sure where the "quick start guide" ends and where the "technical documentation" begins. 

This PR effectively introduces a new landing page for the technical documentation, with links to the other (existing) sections. Due to the nature of the technical documentation tool, this is the most straightforward solution I could devise.

This represents a significant change to content in terms of user journey, so needs to be reviewed by another technical writer (@J-Lambo). In terms of Registers, anyone is free to review. 

### Changes proposed in this pull request
Changes to the relevant files to create a better and clearer user journey for users in terms of where their journey on the docs side begins. Also some minor language changes surrounding "getting started". 

### Guidance to review
This is up for review on https://registers-docs-testing-2.cloudapps.digital/

The live docs are at: https://docs.registers.service.gov.uk/

