### PR TITLE
[DONOTMERGE] Remove API key flow from quick start guide

### DIFF
--- a/source/documentation/quick_start_guide/authenticate_with_your_api_key.md
+++ b/source/documentation/quick_start_guide/authenticate_with_your_api_key.md
@@ -1,6 +1,0 @@
-### Authenticate with your API key 
-
-You should include your key in all requests using the `Authorization` header:
-
-`curl https://country.register.gov.uk/records/GB.json --header 'Authorization: YOUR-API-KEY-HERE'`
-

--- a/source/documentation/quick_start_guide/choose_a_response_format.md
+++ b/source/documentation/quick_start_guide/choose_a_response_format.md
@@ -13,10 +13,10 @@ Choose a response format by adding the appropriate suffix to the request URL:
 For example: 
 
 ```
-curl https://country.register.gov.uk/records/GB.json --header 'Authorization: YOUR-API-KEY-HERE'
+curl https://country.register.gov.uk/records/GB.json 
 ```
 
 You can also specify a format by making a request with the `Accept` header. For example:
 
 ```
-curl https://country.register.gov.uk/records/GB --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'
+curl https://country.register.gov.uk/records/GB --header 'Accept: application/json' 

--- a/source/documentation/quick_start_guide/generate_an_api_key.md
+++ b/source/documentation/quick_start_guide/generate_an_api_key.md
@@ -1,6 +1,0 @@
-### Generate an API key
-
-[Create your API key](https://www.registers.service.gov.uk/api_users/new) and fill in the requested information. Your API key will be displayed and emailed to you. 
-
-Your API key can be used for all registers. 
-

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -5,8 +5,6 @@ weight: 10
 
 # GOV.UK Registers<br /> quick start guide
 
-<%= partial 'documentation/quick_start_guide/generate_an_api_key' %>
-<%= partial 'documentation/quick_start_guide/authenticate_with_your_api_key' %>
 <%= partial 'documentation/quick_start_guide/find_the_base_url_for_registers' %>
 <%= partial 'documentation/quick_start_guide/choose_an_endpoint' %>
 <%= partial 'documentation/quick_start_guide/choose_a_response_format' %>


### PR DESCRIPTION
### Context
We're soon removing the API key flow. This PR, assuming it passes review, can be merged in sync with the changes we're pushing in the frontend and elsewhere when that time comes. This needn't necessarily be merged by me if I'm not on Registers that day, but it will need approving beforehand. 

### Changes proposed in this pull request
Changes to the 'QUICK START GUIDE' section in the technical documentation ONLY. 

### Guidance to review
Live docs link: https://docs.registers.service.gov.uk/

(I can push this to a test environment if it's easier for people to review but I thought it would probably be just easy on the rich text preview that GitHub offers)