### PR TITLE
[DONOTMERGE] Remove YOUR-API-KEY-FLOW from getting updates example

### DIFF
--- a/source/documentation/getting_updates/getting_updates.md
+++ b/source/documentation/getting_updates/getting_updates.md
@@ -12,7 +12,6 @@ For example, your last highest entry number from the `government-organisation` r
 GET /entries/?start=751 HTTP/1.1
 Host: goverment-organisation.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 If there are no updates, you will receive an empty response. If there are updates, you will receive the new entries in the response.


### PR DESCRIPTION
### Context
We're soon removing the API key flow. This PR, assuming it passes review, can be merged in sync with the changes we're pushing in the frontend and elsewhere when that time comes. This needn't necessarily be merged by me if I'm not on Registers that day, but it will need approving beforehand.

### Changes proposed in this pull request
Changes to the GETTING UPDATES section in the technical documentation ONLY.

### Guidance to review
Live docs link: https://docs.registers.service.gov.uk/

(I can push this to a test environment if it's easier for people to review but I thought it would probably be just easy on the rich text preview that GitHub offers)