### PR TITLE
[DONOTMERGE] Remove api key flow from API reference

### DIFF
--- a/source/documentation/api_reference/get_download_register.md
+++ b/source/documentation/api_reference/get_download_register.md
@@ -4,7 +4,6 @@ Download the full contents of the register in a ZIP file.
 GET /download-register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.

--- a/source/documentation/api_reference/get_entries.md
+++ b/source/documentation/api_reference/get_entries.md
@@ -9,7 +9,6 @@ Parameters:
 GET /entries/?start=1&limit=10 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_entries_entry_number.md
+++ b/source/documentation/api_reference/get_entries_entry_number.md
@@ -4,7 +4,6 @@ Get a specific entry from a register.
 GET /entries/204/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_items_item_hash.md
+++ b/source/documentation/api_reference/get_items_item_hash.md
@@ -4,7 +4,6 @@ Get a specific item within a register.
 GET /items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records.md
+++ b/source/documentation/api_reference/get_records.md
@@ -9,7 +9,6 @@ Parameters:
 GET /records/?page-index=1&page-size=3 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_field_name_field_value.md
+++ b/source/documentation/api_reference/get_records_field_name_field_value.md
@@ -11,7 +11,6 @@ Parameters:
 GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_key.md
+++ b/source/documentation/api_reference/get_records_key.md
@@ -8,7 +8,6 @@ Parameters:
 GET /records/KIN HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_key_entries.md
+++ b/source/documentation/api_reference/get_records_key_entries.md
@@ -8,7 +8,6 @@ Parameters:
 GET /records/KIN/entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_register.md
+++ b/source/documentation/api_reference/get_register.md
@@ -4,7 +4,6 @@ Get information about a register.
 GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/getting_updates/getting_updates.md
+++ b/source/documentation/getting_updates/getting_updates.md
@@ -12,7 +12,6 @@ For example, your last highest entry number from the `government-organisation` r
 GET /entries/?start=751 HTTP/1.1
 Host: goverment-organisation.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 If there are no updates, you will receive an empty response. If there are updates, you will receive the new entries in the response.


### PR DESCRIPTION
### Context
We're soon removing the API key flow. This PR, assuming it passes review, can be merged in sync with the changes we're pushing in the frontend and elsewhere when that time comes. This needn't necessarily be merged by me if I'm not on Registers that day, but it will need approving beforehand.

### Changes proposed in this pull request
Changes to the API REFERENCE section in the technical documentation ONLY.

### Guidance to review
Live docs link: https://docs.registers.service.gov.uk/

(I can push this to a test environment if it's easier for people to review but I thought it would probably be just easy on the rich text preview that GitHub offers)