### PR TITLE
Adds example request/example response format

### DIFF
--- a/source/documentation/api_reference/get_download_register.md
+++ b/source/documentation/api_reference/get_download_register.md
@@ -1,5 +1,7 @@
 Download the full contents of the register in a ZIP file.
 
+Example request:
+
 ```http
 GET /download-register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk

--- a/source/documentation/api_reference/get_entries.md
+++ b/source/documentation/api_reference/get_entries.md
@@ -5,12 +5,16 @@ Parameters:
 * `start` (Optional): Collection page number. Defaults to 1.
 * `limit` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
+Example request:
+
 ```http
 GET /entries/?start=1&limit=10 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_entries_entry_number.md
+++ b/source/documentation/api_reference/get_entries_entry_number.md
@@ -1,11 +1,15 @@
 Get a specific entry from a register.
 
+Example request:
+
 ```http
 GET /entries/204/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_items_item_hash.md
+++ b/source/documentation/api_reference/get_items_item_hash.md
@@ -1,11 +1,15 @@
 Get a specific item within a register.
 
+Example request:
+
 ```http
 GET /items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_records.md
+++ b/source/documentation/api_reference/get_records.md
@@ -5,12 +5,16 @@ Parameters:
 * `page-index` (Optional): Collection page number. Defaults to 1.
 * `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
+Example request:
+
 ```http
 GET /records/?page-index=1&page-size=3 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_records_field_name_field_value.md
+++ b/source/documentation/api_reference/get_records_field_name_field_value.md
@@ -7,12 +7,16 @@ Parameters:
 * `page-index` (Optional): Collection page number. Defaults to 1.
 * `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
+Example request:
+
 ```http
 GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_records_key.md
+++ b/source/documentation/api_reference/get_records_key.md
@@ -4,12 +4,16 @@ Parameters:
 
 * `key` (Required): A unique UTF-8 string which identifies something in a register.
 
+Example request:
+
 ```http
 GET /records/KIN HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_records_key_entries.md
+++ b/source/documentation/api_reference/get_records_key_entries.md
@@ -4,12 +4,16 @@ Parameters:
 
 * `key` (Required): A unique UTF-8 string which identifies something in a register.
 
+Example request:
+
 ```http
 GET /records/KIN/entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200

--- a/source/documentation/api_reference/get_register.md
+++ b/source/documentation/api_reference/get_register.md
@@ -1,11 +1,15 @@
 Get information about a register.
 
+Example request:
+
 ```http
 GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE
 ```
+
+Example response:
 
 ```http
 HTTP/1.1 200


### PR DESCRIPTION
### Context
In the absence of a real API explorer for our docs, we should make it clear in our reference section that the content we present are examples

### Changes proposed in this pull request
"Example request" and "Example response" language

### Guidance to review
Rich-text preview if necessary to see how this will be rendered