### PR TITLE
Remove 'therubyracer' from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,3 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 gem 'govuk_tech_docs', '~> 1.5.0'
-
-gem 'therubyracer'


### PR DESCRIPTION
### Context
This was added because of https://github.com/alphagov/registers-tech-docs/pull/47#pullrequestreview-111624149 but it isn't necessary any more to build, and has actually been linked to recent hangs/crashes of the tech docs tool, so I'd like to remove it. It shouldn't have any impact, but if it does, it's an easily identifiable fix.


### Changes proposed in this pull request
Removes 'therubyracer' from Gemfile

