### PR TITLE
'View' -> 'Get'

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -15,7 +15,7 @@ on top of a register to fulfil specific requests.
 
 Using different endpoints, you can:
 
-* view [information about a register](/api_reference/get_register#get-register) 
+* get [information about a register](/api_reference/get_register#get-register) 
 * get all [records from a register](/api_reference/get_records#get-records) 
 * get a [specific record within a register based on a particular key](/api_reference/get_records_key#get-records-key) 
 * get all [entries for a single record based on a particular key](/api_reference/get_records_key_entries#get-records-key-entries) 


### PR DESCRIPTION

### Context
To bring in line with rest of content, there's no reason this should be 'view' so it should be 'get' instead.

### Changes proposed in this pull request
Change of one word from 'view' to 'get'

