### PR TITLE
Remove api key flow

### DIFF
--- a/source/documentation/api_reference/get_download_register.md
+++ b/source/documentation/api_reference/get_download_register.md
@@ -6,7 +6,6 @@ Example request:
 GET /download-register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.

--- a/source/documentation/api_reference/get_download_register.md
+++ b/source/documentation/api_reference/get_download_register.md
@@ -4,7 +4,6 @@ Download the full contents of the register in a ZIP file.
 GET /download-register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 This will download every entry and item as an individual JSON file. If you only want to download records, use `GET /records`.

--- a/source/documentation/api_reference/get_entries.md
+++ b/source/documentation/api_reference/get_entries.md
@@ -11,7 +11,6 @@ Example request:
 GET /entries/?start=1&limit=10 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_entries.md
+++ b/source/documentation/api_reference/get_entries.md
@@ -9,7 +9,6 @@ Parameters:
 GET /entries/?start=1&limit=10 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_entries_entry_number.md
+++ b/source/documentation/api_reference/get_entries_entry_number.md
@@ -4,7 +4,6 @@ Get a specific entry from a register.
 GET /entries/204/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_entries_entry_number.md
+++ b/source/documentation/api_reference/get_entries_entry_number.md
@@ -6,7 +6,6 @@ Example request:
 GET /entries/204/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_items_item_hash.md
+++ b/source/documentation/api_reference/get_items_item_hash.md
@@ -4,7 +4,6 @@ Get a specific item within a register.
 GET /items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_items_item_hash.md
+++ b/source/documentation/api_reference/get_items_item_hash.md
@@ -6,7 +6,6 @@ Example request:
 GET /items/sha-256:6c4c815895ea675857ee4ec3fb40571ce54faf5ebcdd5d73a2aae347d4003c31/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_records.md
+++ b/source/documentation/api_reference/get_records.md
@@ -11,7 +11,6 @@ Example request:
 GET /records/?page-index=1&page-size=3 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_records.md
+++ b/source/documentation/api_reference/get_records.md
@@ -9,7 +9,6 @@ Parameters:
 GET /records/?page-index=1&page-size=3 HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_field_name_field_value.md
+++ b/source/documentation/api_reference/get_records_field_name_field_value.md
@@ -11,7 +11,6 @@ Parameters:
 GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_field_name_field_value.md
+++ b/source/documentation/api_reference/get_records_field_name_field_value.md
@@ -13,7 +13,6 @@ Example request:
 GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_records_key.md
+++ b/source/documentation/api_reference/get_records_key.md
@@ -10,7 +10,6 @@ Example request:
 GET /records/KIN HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_records_key.md
+++ b/source/documentation/api_reference/get_records_key.md
@@ -8,7 +8,6 @@ Parameters:
 GET /records/KIN HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_key_entries.md
+++ b/source/documentation/api_reference/get_records_key_entries.md
@@ -8,7 +8,6 @@ Parameters:
 GET /records/KIN/entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/api_reference/get_records_key_entries.md
+++ b/source/documentation/api_reference/get_records_key_entries.md
@@ -10,7 +10,6 @@ Example request:
 GET /records/KIN/entries/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_register.md
+++ b/source/documentation/api_reference/get_register.md
@@ -6,7 +6,6 @@ Example request:
 GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 Example response:

--- a/source/documentation/api_reference/get_register.md
+++ b/source/documentation/api_reference/get_register.md
@@ -4,7 +4,6 @@ Get information about a register.
 GET /register/ HTTP/1.1
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 ```http

--- a/source/documentation/getting_updates/getting_updates.md
+++ b/source/documentation/getting_updates/getting_updates.md
@@ -12,7 +12,6 @@ For example, your last highest entry number from the `government-organisation` r
 GET /entries/?start=751 HTTP/1.1
 Host: goverment-organisation.register.gov.uk
 Accept: application/json
-Authorization: YOUR-API-KEY-HERE
 ```
 
 If there are no updates, you will receive an empty response. If there are updates, you will receive the new entries in the response.

--- a/source/documentation/quick_start_guide/authenticate_with_your_api_key.md
+++ b/source/documentation/quick_start_guide/authenticate_with_your_api_key.md
@@ -1,6 +1,0 @@
-### Authenticate with your API key 
-
-You should include your key in all requests using the `Authorization` header:
-
-`curl https://country.register.gov.uk/records/GB.json --header 'Authorization: YOUR-API-KEY-HERE'`
-

--- a/source/documentation/quick_start_guide/choose_a_response_format.md
+++ b/source/documentation/quick_start_guide/choose_a_response_format.md
@@ -13,10 +13,10 @@ Choose a response format by adding the appropriate suffix to the request URL:
 For example: 
 
 ```
-curl https://country.register.gov.uk/records/GB.json --header 'Authorization: YOUR-API-KEY-HERE'
+curl https://country.register.gov.uk/records/GB.json 
 ```
 
 You can also specify a format by making a request with the `Accept` header. For example:
 
 ```
-curl https://country.register.gov.uk/records/GB --header 'Accept: application/json' --header 'Authorization: YOUR-API-KEY-HERE'
+curl https://country.register.gov.uk/records/GB --header 'Accept: application/json' 

--- a/source/documentation/quick_start_guide/generate_an_api_key.md
+++ b/source/documentation/quick_start_guide/generate_an_api_key.md
@@ -1,6 +1,0 @@
-### Generate an API key
-
-[Create your API key](https://www.registers.service.gov.uk/api_users/new) and fill in the requested information. Your API key will be displayed and emailed to you. 
-
-Your API key can be used for all registers. 
-

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -5,8 +5,6 @@ weight: 10
 
 # GOV.UK Registers<br /> quick start guide
 
-<%= partial 'documentation/quick_start_guide/generate_an_api_key' %>
-<%= partial 'documentation/quick_start_guide/authenticate_with_your_api_key' %>
 <%= partial 'documentation/quick_start_guide/find_the_base_url_for_registers' %>
 <%= partial 'documentation/quick_start_guide/choose_an_endpoint' %>
 <%= partial 'documentation/quick_start_guide/choose_a_response_format' %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -11,4 +11,3 @@ Use the technical documentation to find out:
 - what components make up registers
 - how registers are linked
 - how to make sure the data you use is up to date
-

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -5,8 +5,6 @@ weight: 10
 
 # Quick start guide
 
-<%= partial 'documentation/quick_start_guide/generate_an_api_key' %>
-<%= partial 'documentation/quick_start_guide/authenticate_with_your_api_key' %>
 <%= partial 'documentation/quick_start_guide/find_the_base_url_for_registers' %>
 <%= partial 'documentation/quick_start_guide/choose_an_endpoint' %>
 <%= partial 'documentation/quick_start_guide/choose_a_response_format' %>


### PR DESCRIPTION
### Context
Removes API key flow completely from all tech docs, in a single PR 

### Changes proposed in this pull request
Removes all mentions of API key from all relevant files within docs, and accounts for new landing page structure
