### PR TITLE
Remove parameters from facets endpoint

### DIFF
--- a/source/documentation/api_reference/get_records_field_name_field_value.md
+++ b/source/documentation/api_reference/get_records_field_name_field_value.md
@@ -4,13 +4,11 @@ Parameters:
 
 * `field-name` (Required): Field name. 
 * `field-value` (Required): Field value. 
-* `page-index` (Optional): Collection page number. Defaults to 1.
-* `page-size` (Optional): Collection page size. Defaults to 100. Maximum is 5000. 
 
 Example request:
 
 ```http
-GET /records/local-authority-type/CTY/?page-index=1&page-size=3 HTTP/1.1 
+GET /records/local-authority-type/CTY/ HTTP/1.1 
 Host: local-authority-eng.register.gov.uk
 Accept: application/json
 Authorization: YOUR-API-KEY-HERE


### PR DESCRIPTION
### Context
The current docs say the facets endpoint accept `page-index` and `page-size` but the reference implementation doesn't implement them.

### Changes proposed in this pull request
Removes references to `page-index` and `page-size` as optional parameters and query parameters.