### PR TITLE
Format changes

### DIFF
--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -1,13 +1,15 @@
 ---
-title: API reference 
+title: API reference
 weight: 50
 ---
 
-# API reference 
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
-Each register has an open, RESTful API you can use to access the data. 
+# API reference
 
-Each register API is read-only. 
+Each register has an open, RESTful API you can use to access the data.
+
+Each register API is read-only.
 
 Registers only provide raw data. You cannot use the APIs to search a register
 or match data. Depending on your requirements, you may have to build indexes
@@ -15,12 +17,12 @@ on top of a register to fulfil specific requests.
 
 Using different endpoints, you can:
 
-* get [information about a register](/api_reference/get_register#get-register) 
-* get all [records from a register](/api_reference/get_records#get-records) 
-* get a [specific record within a register based on a particular key](/api_reference/get_records_key#get-records-key) 
-* get all [entries for a single record based on a particular key](/api_reference/get_records_key_entries#get-records-key-entries) 
-* get all [records that share a `field-value` for a particular field](/api_reference/get_records_field_name_field_value#get-records-field-name-field-value) 
+* get [information about a register](/api_reference/get_register#get-register)
+* get all [records from a register](/api_reference/get_records#get-records)
+* get a [specific record within a register based on a particular key](/api_reference/get_records_key#get-records-key)
+* get all [entries for a single record based on a particular key](/api_reference/get_records_key_entries#get-records-key-entries)
+* get all [records that share a `field-value` for a particular field](/api_reference/get_records_field_name_field_value#get-records-field-name-field-value)
 * get all [entries from a register](/api_reference/get_entries#get-entries)
 * get a [specific entry from a register](/api_reference/get_entries_entry_number#get-entries-entry-number)
 * get a [specific item within a register](/api_reference/get_items_item_hash#get-items-item-hash)
-* download the [full contents of a register in a ZIP file](/api_reference/get_download_register#get-download-register) 
+* download the [full contents of a register in a ZIP file](/api_reference/get_download_register#get-download-register)

--- a/source/documentation/data_format_deprecation_notice.md
+++ b/source/documentation/data_format_deprecation_notice.md
@@ -1,0 +1,6 @@
+<aside class="notice">
+    <div class="container">
+      <p class="visually-hidden">Upcoming data format changes</p>
+      <p data-click-events data-click-category="Content" data-click-action="Notice link clicked">GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. <a href="https://registers.service.gov.uk/data-format-changes">Read more about format changes</a></p>
+  </div>
+</aside>

--- a/source/documentation/quick_start_guide/choose_a_response_format.md
+++ b/source/documentation/quick_start_guide/choose_a_response_format.md
@@ -5,10 +5,7 @@ Choose a response format by adding the appropriate suffix to the request URL:
 | Format | Suffix | Media type |
 |--------|--------|------------|
 | JSON | .json | application/json |
-| YAML | .yaml | text/ yaml |
 | CSV | .csv | text/csv |
-| TSV | .tsv | text/tsv |
-| Turtle | .ttl | text/ttl |
 
 For example: 
 

--- a/source/getting_updates/index.html.md.erb
+++ b/source/getting_updates/index.html.md.erb
@@ -2,6 +2,7 @@
 title: Getting updates
 weight: 40
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Getting updates
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,7 +3,9 @@ title: GOV.UK Registers technical documentation
 weight: 05
 ---
 
-# GOV.UK Registers technical documentation 
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
+
+# GOV.UK Registers technical documentation
 
 Use the technical documentation to find out:
 
@@ -11,4 +13,3 @@ Use the technical documentation to find out:
 - what components make up registers
 - how registers are linked
 - how to make sure the data you use is up to date
-

--- a/source/linked_registers/index.html.md.erb
+++ b/source/linked_registers/index.html.md.erb
@@ -2,8 +2,9 @@
 title: Linked registers
 weight: 30
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
-# Linked registers 
+# Linked registers
 
 <%= partial 'documentation/linked_registers/linked_registers' %>
 <%= partial 'documentation/linked_registers/curies' %>

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -2,6 +2,7 @@
 title: Quick start guide
 weight: 10
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Quick start guide
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,35 @@
 @import "govuk_tech_docs";
+
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.notice {
+  background-color: $grey-4;
+  border-bottom: 1px solid $border-colour;
+  border-top: 1px solid $border-colour;
+  padding: 0 16px;
+  margin-top: 24px;
+
+  .container {
+    margin-bottom: 0;
+  }
+
+  p {
+    @include core-16;
+
+    margin: 0;
+    padding: ($gutter / 2) 0;
+  }
+}
+
+.technical-documentation h1:first-of-type {
+  margin-top: 0 !important;
+}

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -1,9 +1,10 @@
 ---
-title: Support 
+title: Support
 weight: 80
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
-# Support  
+# Support
 
 <%= partial 'documentation/support/if_you_cannot_find_a_specific_record' %>
 <%= partial 'documentation/support/technical_specification' %>

--- a/source/the_components_of_a_register/index.html.md.erb
+++ b/source/the_components_of_a_register/index.html.md.erb
@@ -2,6 +2,7 @@
 title: The components of a register
 weight: 20
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # The components of a register
 


### PR DESCRIPTION
### Context
We will be removing support for certain formats.

Our spec is in JSON and most users of registers use JSON
We know this from Analyse historic access by format and by register

We should streamline the number of formats that we offer on registers

Proposed: JSON, CSV, (later on JSON-LD, CSV-LD)

Remove the others: HTML, YAML, Turtle to minimise complexity in the implementation

### Changes proposed in this pull request

Remove formats on offer in quick start section that don't conform to proposed changes. This *does not yet have the banner*: we may want a separate PR for that.
