### PR TITLE
Format changes

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,10 @@
 ---
 applications:
-- name: registers-docs
+- name: registers-docs-testing2
   memory: 64M
   instances: 2
   buildpack: staticfile_buildpack
   routes:
-    - route: docs.registers.service.gov.uk
+    - route: registers-docs-testing2.cloudapps.digital
   services:
     - logit-ssl-drain

--- a/source/api_reference/get_download_register/index.html.md.erb
+++ b/source/api_reference/get_download_register/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 90
 ---
 
 # <a name="get-download-register">`GET /download-register`</a>
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_download_register' %>

--- a/source/api_reference/get_entries/index.html.md.erb
+++ b/source/api_reference/get_entries/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 60
 ---
 
 # <a name="get-entries">`GET /entries`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_entries' %>

--- a/source/api_reference/get_entries_entry_number/index.html.md.erb
+++ b/source/api_reference/get_entries_entry_number/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 70
 ---
 
 # <a name="get-entries-entry-number">`GET /entries/{entry-number}`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_entries_entry_number' %>

--- a/source/api_reference/get_items_item_hash/index.html.md.erb
+++ b/source/api_reference/get_items_item_hash/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 80
 ---
 
 # <a name="get-items-item-hash">`GET /items/{item-hash}`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_items_item_hash' %>

--- a/source/api_reference/get_records/index.html.md.erb
+++ b/source/api_reference/get_records/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 20
 ---
 
 # <a name="get-records">`GET /records`</a>
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_records' %>

--- a/source/api_reference/get_records_field_name_field_value/index.html.md.erb
+++ b/source/api_reference/get_records_field_name_field_value/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 50
 ---
 
 # <a name="get-records-field-name-field-value">`GET /records/{field-name}/{field-value}`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_records_field_name_field_value' %>

--- a/source/api_reference/get_records_key/index.html.md.erb
+++ b/source/api_reference/get_records_key/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 30
 ---
 
 # <a name="get-records-key">`GET /records/{key}`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_records_key' %>

--- a/source/api_reference/get_records_key_entries/index.html.md.erb
+++ b/source/api_reference/get_records_key_entries/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 40
 ---
 
 # <a name="get-records-key-entries">`GET /records/{key}/entries`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_records_key_entries' %>

--- a/source/api_reference/get_register/index.html.md.erb
+++ b/source/api_reference/get_register/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 10
 ---
 
 # <a name="getregister">`GET /register`</a>	
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/get_register' %>

--- a/source/api_reference/http_status_codes/index.html.md.erb
+++ b/source/api_reference/http_status_codes/index.html.md.erb
@@ -4,5 +4,6 @@ weight: 100
 ---
 
 # <a name="http-status-codes">HTTP status codes</a>
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/http_status_codes' %>

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -3,9 +3,9 @@ title: API reference
 weight: 50
 ---
 
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
-
 # API reference
+
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 Each register has an open, RESTful API you can use to access the data.
 

--- a/source/api_reference/index.html.md.erb
+++ b/source/api_reference/index.html.md.erb
@@ -1,13 +1,15 @@
 ---
-title: API reference 
+title: API reference
 weight: 50
 ---
 
-# API reference 
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
-Each register has an open, RESTful API you can use to access the data. 
+# API reference
 
-Each register API is read-only. 
+Each register has an open, RESTful API you can use to access the data.
+
+Each register API is read-only.
 
 Registers only provide raw data. You cannot use the APIs to search a register
 or match data. Depending on your requirements, you may have to build indexes
@@ -15,12 +17,12 @@ on top of a register to fulfil specific requests.
 
 Using different endpoints, you can:
 
-* get [information about a register](/api_reference/get_register#get-register) 
-* get all [records from a register](/api_reference/get_records#get-records) 
-* get a [specific record within a register based on a particular key](/api_reference/get_records_key#get-records-key) 
-* get all [entries for a single record based on a particular key](/api_reference/get_records_key_entries#get-records-key-entries) 
-* get all [records that share a `field-value` for a particular field](/api_reference/get_records_field_name_field_value#get-records-field-name-field-value) 
+* get [information about a register](/api_reference/get_register#get-register)
+* get all [records from a register](/api_reference/get_records#get-records)
+* get a [specific record within a register based on a particular key](/api_reference/get_records_key#get-records-key)
+* get all [entries for a single record based on a particular key](/api_reference/get_records_key_entries#get-records-key-entries)
+* get all [records that share a `field-value` for a particular field](/api_reference/get_records_field_name_field_value#get-records-field-name-field-value)
 * get all [entries from a register](/api_reference/get_entries#get-entries)
 * get a [specific entry from a register](/api_reference/get_entries_entry_number#get-entries-entry-number)
 * get a [specific item within a register](/api_reference/get_items_item_hash#get-items-item-hash)
-* download the [full contents of a register in a ZIP file](/api_reference/get_download_register#get-download-register) 
+* download the [full contents of a register in a ZIP file](/api_reference/get_download_register#get-download-register)

--- a/source/api_reference/rate_limits/index.html.md.erb
+++ b/source/api_reference/rate_limits/index.html.md.erb
@@ -3,5 +3,6 @@ title: Rate limits
 weight: 110
 ---
 
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/api_reference/rate_limits' %>

--- a/source/documentation/data_format_deprecation_notice.md
+++ b/source/documentation/data_format_deprecation_notice.md
@@ -1,0 +1,6 @@
+<aside class="notice">
+    <div class="container">
+      <p class="visually-hidden">Upcoming data format changes</p>
+      <p data-click-events data-click-category="Content" data-click-action="Notice link clicked">GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. <a href="https://registers.service.gov.uk/data-format-changes">Read more about format changes</a></p>
+  </div>
+</aside>

--- a/source/documentation/data_format_deprecation_notice.md
+++ b/source/documentation/data_format_deprecation_notice.md
@@ -1,6 +1,6 @@
 <aside class="notice">
     <div class="container">
       <p class="visually-hidden">Upcoming data format changes</p>
-      <p data-click-events data-click-category="Content" data-click-action="Notice link clicked">GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. <a href="https://registers.service.gov.uk/data-format-changes">Read more about format changes</a></p>
+      <p data-click-events data-click-category="Content" data-click-action="Notice link clicked">GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. <a href="https://www.registers.service.gov.uk/data-format-changes">Read more about format changes</a></p>
   </div>
 </aside>

--- a/source/documentation/quick_start_guide/choose_a_response_format.md
+++ b/source/documentation/quick_start_guide/choose_a_response_format.md
@@ -5,10 +5,7 @@ Choose a response format by adding the appropriate suffix to the request URL:
 | Format | Suffix | Media type |
 |--------|--------|------------|
 | JSON | .json | application/json |
-| YAML | .yaml | text/ yaml |
 | CSV | .csv | text/csv |
-| TSV | .tsv | text/tsv |
-| Turtle | .ttl | text/ttl |
 
 For example: 
 

--- a/source/getting_updates/index.html.md.erb
+++ b/source/getting_updates/index.html.md.erb
@@ -2,6 +2,7 @@
 title: Getting updates
 weight: 40
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Getting updates
 

--- a/source/getting_updates/index.html.md.erb
+++ b/source/getting_updates/index.html.md.erb
@@ -2,8 +2,9 @@
 title: Getting updates
 weight: 40
 ---
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Getting updates
+
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/getting_updates/getting_updates' %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,9 +3,8 @@ title: GOV.UK Registers technical documentation
 weight: 05
 ---
 
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
-
 # GOV.UK Registers technical documentation
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 Use the technical documentation to find out:
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,7 +3,9 @@ title: GOV.UK Registers technical documentation
 weight: 05
 ---
 
-# GOV.UK Registers technical documentation 
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
+
+# GOV.UK Registers technical documentation
 
 Use the technical documentation to find out:
 
@@ -11,4 +13,3 @@ Use the technical documentation to find out:
 - what components make up registers
 - how registers are linked
 - how to make sure the data you use is up to date
-

--- a/source/linked_registers/index.html.md.erb
+++ b/source/linked_registers/index.html.md.erb
@@ -2,9 +2,9 @@
 title: Linked registers
 weight: 30
 ---
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Linked registers
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/linked_registers/linked_registers' %>
 <%= partial 'documentation/linked_registers/curies' %>

--- a/source/linked_registers/index.html.md.erb
+++ b/source/linked_registers/index.html.md.erb
@@ -2,8 +2,9 @@
 title: Linked registers
 weight: 30
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
-# Linked registers 
+# Linked registers
 
 <%= partial 'documentation/linked_registers/linked_registers' %>
 <%= partial 'documentation/linked_registers/curies' %>

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -2,6 +2,7 @@
 title: Quick start guide
 weight: 10
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Quick start guide
 

--- a/source/quick_start_guide/index.html.md.erb
+++ b/source/quick_start_guide/index.html.md.erb
@@ -2,9 +2,9 @@
 title: Quick start guide
 weight: 10
 ---
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Quick start guide
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/quick_start_guide/generate_an_api_key' %>
 <%= partial 'documentation/quick_start_guide/authenticate_with_your_api_key' %>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,35 @@
 @import "govuk_tech_docs";
+
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.notice {
+  background-color: $grey-4;
+  border-bottom: 1px solid $border-colour;
+  border-top: 1px solid $border-colour;
+  padding: 0 16px;
+  margin-top: 24px;
+
+  .container {
+    margin-bottom: 0;
+  }
+
+  p {
+    @include core-16;
+
+    margin: 0;
+    padding: ($gutter / 2) 0;
+  }
+}
+
+.technical-documentation h1:first-of-type {
+  margin-top: 0 !important;
+}

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -1,9 +1,10 @@
 ---
-title: Support 
+title: Support
 weight: 80
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
-# Support  
+# Support
 
 <%= partial 'documentation/support/if_you_cannot_find_a_specific_record' %>
 <%= partial 'documentation/support/technical_specification' %>

--- a/source/support/index.html.md.erb
+++ b/source/support/index.html.md.erb
@@ -2,10 +2,30 @@
 title: Support
 weight: 80
 ---
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # Support
+<%= partial 'documentation/data_format_deprecation_notice.md' %> 
 
 <%= partial 'documentation/support/if_you_cannot_find_a_specific_record' %>
 <%= partial 'documentation/support/technical_specification' %>
 <%= partial 'documentation/support/contact_us' %>
+
+Each register has an open, RESTful API you can use to access the data.
+
+Each register API is read-only.
+
+Registers only provide raw data. You cannot use the APIs to search a register
+or match data. Depending on your requirements, you may have to build indexes
+on top of a register to fulfil specific requests.
+
+Using different endpoints, you can:
+
+* get [information about a register](/api_reference/get_register#get-register)
+* get all [records from a register](/api_reference/get_records#get-records)
+* get a [specific record within a register based on a particular key](/api_reference/get_records_key#get-records-key)
+* get all [entries for a single record based on a particular key](/api_reference/get_records_key_entries#get-records-key-entries)
+* get all [records that share a `field-value` for a particular field](/api_reference/get_records_field_name_field_value#get-records-field-name-field-value)
+* get all [entries from a register](/api_reference/get_entries#get-entries)
+* get a [specific entry from a register](/api_reference/get_entries_entry_number#get-entries-entry-number)
+* get a [specific item within a register](/api_reference/get_items_item_hash#get-items-item-hash)
+* download the [full contents of a register in a ZIP file](/api_reference/get_download_register#get-download-register)

--- a/source/the_components_of_a_register/index.html.md.erb
+++ b/source/the_components_of_a_register/index.html.md.erb
@@ -2,6 +2,7 @@
 title: The components of a register
 weight: 20
 ---
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # The components of a register
 

--- a/source/the_components_of_a_register/index.html.md.erb
+++ b/source/the_components_of_a_register/index.html.md.erb
@@ -2,9 +2,9 @@
 title: The components of a register
 weight: 20
 ---
-<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 # The components of a register
+<%= partial 'documentation/data_format_deprecation_notice.md' %>
 
 <%= partial 'documentation/the_components_of_a_register/the_components_of_a_register' %>
 <%= partial 'documentation/the_components_of_a_register/entries' %>


### PR DESCRIPTION
### Context
We need a banner to indicate our upcoming format changes and we should no longer advertise soon-to-be-deprecated formats anywhere else in the docs.

### Changes proposed in this pull request
A single PR for all the format changes, with the banner below the headers to avoid the scrolling problem described in https://github.com/alphagov/registers-tech-docs/pull/128

### Guidance to review
https://registers-docs-testing2.cloudapps.digital/