### PR TITLE
Updates link to registers collection

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,7 @@ phase: Alpha
 
 # Links to show on right-hand-side of header
 header_links:
-  Get data: https://www.registers.service.gov.uk/registers
+  Registers collection: https://www.registers.service.gov.uk/registers
   Support: https://www.registers.service.gov.uk/support
   Documentation: /
 


### PR DESCRIPTION
### Context
The navigation link to the registers has been changed to read 'Registers collection' on the frontend; this change does the same for the documentation navigation. (See this [card](https://trello.com/c/GDGJm4ql/3067-update-header-and-footer))

### Changes proposed in this pull request
 * Link text changed from 'Get data' to 'Registers collection'

### Guidance to review
None.