### PR TITLE
Explain that blob-hash is different to item-hash

### DIFF
--- a/source/api_reference/version-history/index.html.md.erb
+++ b/source/api_reference/version-history/index.html.md.erb
@@ -37,7 +37,8 @@ Registers no longer have "indexes" ([RFC-20](https://github.com/openregister/reg
 These changes mean that:
 
 - you now access the resource at `/blobs/{blob-hash}` instead of `/items/{item-hash}`
-- the field `item-hash` is now named `blob-hash`
+- the field `item-hash` has been replaced by `blob-hash`
+- `blob-hash` is computed differently from the existing `item-hash` vaues, so if your code relies on [updates](/getting_updates), you should fetch all the data again after updating to this version of the API
 - the field `index-entry-number` no longer exists (use `entry-number` instead)
 - `/entries/{entry-number}` now returns a single object instead of an array of objects
 - `/records/{key}` now returns a record object, instead of an object indexed by the entry key


### PR DESCRIPTION
### Context
The change notes for the API previously said that `item-hash` was renamed to `blob-hash`. This is misleading as the actual values have changed as well.

### Changes proposed in this pull request
Explain that `blob-hash` is a replacement for `item-hash`. It should only affect a minority of users who rely on partial updates (using the entry/item API).

### Guidance to review
- Check words make sense