### PR TITLE
Add changenotes for the context endpoint

### DIFF
--- a/source/api_reference/version-history/index.html.md.erb
+++ b/source/api_reference/version-history/index.html.md.erb
@@ -37,9 +37,9 @@ The registers data model has changed since v1 of the API:
 These changes mean that:
 
 - you now access the resource at `/blobs/{blob-hash}` instead of `/items/{item-hash}`
-- the field `item-hash` has been replaced by `blob-hash`
+- the `item-hash` attribute has been replaced by `blob-hash`
 - `blob-hash` is computed differently from the existing `item-hash` vaues, so if your code relies on [updates](/getting_updates), you should fetch all the data again after updating to this version of the API
-- the field `index-entry-number` no longer exists (use `entry-number` instead)
+- the `index-entry-number` attribute no longer exists (use `entry-number` instead)
 - `/entries/{entry-number}` now returns a single object instead of an array of objects
 
 - `/records/{key}` now returns a flat record object with the entry key using the reserved field `_id`,  instead of an object indexed by the entry key. In addition the `entry-number` and `entry-timestamp` have been removed from the object. If you require these you can get them using the `/records/{key}/entries` endpoint.
@@ -52,6 +52,17 @@ You can use the `/blobs` endpoint to retrieve multiple blobs in a single request
 `/blobs` is paginated, and by default it returns the first 100 blobs in the register. To fetch more data, query the URL provided in the `Link` header that has `rel=next`.
 
 Blobs are returned in the order they were added to the register. This guarantees that complete pages will always contain the same blobs.
+
+### New `/context` endpoint
+The context endpoint replaces `/register` ([RFC 18](https://github.com/openregister/registers-rfcs/blob/master/content/context-resource/index.md)).
+
+This endpoint exposes extra metadata about the schema of a register. Each register field is now an object containing `id`, `datatype` and `cardinality` attributes.
+
+The following attributes are no longer included in the response:
+
+- `phase` (use the `start-date`/`end-date` attributes of the `status` object to determine whether the register is active or retired)
+- `last-updated` (this is the `entry-timestamp` of the last entry returned by `/entries`)
+- `registry`
 
 ### Hash values are formatted using multihash
 


### PR DESCRIPTION
### Context
We replaced `/register` with `/context` in V2.

### Changes proposed in this pull request
Explain what's changed

### Guidance to review
